### PR TITLE
Limit Unsplash images to featured images only

### DIFF
--- a/randomwallpaper@iflow.space/sourceAdapter.js
+++ b/randomwallpaper@iflow.space/sourceAdapter.js
@@ -93,6 +93,7 @@ let UnsplashAdapter = new Lang.Class({
 	options: {
 		'username': '',
 		'query': '',
+		'featured': true,
 		'w': 1920,
 		'h': 1080,
 	},


### PR DESCRIPTION
This limits the Unsplash images to featured images only.  Merge this as is if you'd like but I may attempt to add a toggle for this in the settings if desired.

Resolves #17 