### PR TITLE
Use gi.Soup to download files to fix extension in Gnome 3.34, also use proper inheritance

### DIFF
--- a/randomwallpaper@iflow.space/elements.js
+++ b/randomwallpaper@iflow.space/elements.js
@@ -7,15 +7,17 @@ const GdkPixbuf = imports.gi.GdkPixbuf;
 const Clutter = imports.gi.Clutter;
 const Cogl = imports.gi.Cogl;
 const Gtk = imports.gi.Gtk;
+const GObject = imports.gi.GObject;
 
 const Self = imports.misc.extensionUtils.getCurrentExtension();
 const LoggerModule = Self.imports.logger;
 const Timer = Self.imports.timer;
 
-var HistoryElement = class extends PopupMenu.PopupSubMenuMenuItem {
-
-	constructor(historyEntry, index) {
-		super("", false);
+var HistoryElement = GObject.registerClass({
+			 GTypeName: 'HistoryElement',
+	 }, class HistoryElement extends PopupMenu.PopupSubMenuMenuItem {
+				_init(historyEntry, index) {
+		super._init("", false);
 		this.logger = new LoggerModule.Logger('RWG3', 'HistoryElement');
 		this.historyEntry = null;
 		this.setAsWallpaperItem = null;
@@ -147,20 +149,22 @@ var HistoryElement = class extends PopupMenu.PopupSubMenuMenuItem {
 	setIndex(index) {
 		this.prefixLabel.set_text(String(index));
 	}
+	 }
+);
 
-};
+var CurrentImageElement = GObject.registerClass({
+			 GTypeName: 'CurrentImageElement',
+	 }, class CurrentImageElement extends HistoryElement {
 
-var CurrentImageElement = class extends HistoryElement {
-
-	constructor(historyElement) {
-		super(historyElement, 0);
+	_init(historyElement) {
+		super._init(historyElement, 0);
 
 		if (this.setAsWallpaperItem !== null) {
 			this.setAsWallpaperItem.destroy();
 		}
 	}
 
-};
+});
 
 /**
  * Element for the New Wallpaper button and the remaining time for the auto fetch
@@ -169,10 +173,12 @@ var CurrentImageElement = class extends HistoryElement {
  *
  * @type {Lang.Class}
  */
-var NewWallpaperElement = class extends PopupMenu.PopupBaseMenuItem {
+var NewWallpaperElement = GObject.registerClass({
+			 GTypeName: 'NewWallpaperElement',
+	 }, class NewWallpaperElement extends PopupMenu.PopupBaseMenuItem {
 
-	constructor(params) {
-		super(params);
+	_init(params) {
+		super._init(params);
 
 		this._timer = new Timer.AFTimer();
 
@@ -217,9 +223,9 @@ var NewWallpaperElement = class extends PopupMenu.PopupBaseMenuItem {
 		}
 	}
 
-};
+});
 
-var StatusElement = class {
+class StatusElement {
 
 	constructor() {
 		this.icon = new St.Icon({
@@ -275,7 +281,7 @@ var StatusElement = class {
 
 };
 
-var HistorySection = class extends PopupMenu.PopupMenuSection {
+class HistorySection extends PopupMenu.PopupMenuSection {
 
 	constructor() {
 		super();

--- a/randomwallpaper@iflow.space/wallpaperController.js
+++ b/randomwallpaper@iflow.space/wallpaperController.js
@@ -127,7 +127,7 @@ var WallpaperController = class {
 		let request = Soup.Message.new('GET', uri);
 		request.connect('got_chunk', Lang.bind(this, function(message, chunk){
 			try {
-				fstream.write(chunk.get_data(), null, chunk.length);
+				fstream.write(chunk.get_data(), null);
 			} catch (e) {
 				if (callback) {
 					callback(null, null, e);

--- a/randomwallpaper@iflow.space/wallpaperController.js
+++ b/randomwallpaper@iflow.space/wallpaperController.js
@@ -3,6 +3,10 @@ const Mainloop = imports.gi.GLib;
 // Filesystem
 const Gio = imports.gi.Gio;
 
+// HTTP
+const Soup = imports.gi.Soup;
+const Lang = imports.lang;
+
 //self
 const Self = imports.misc.extensionUtils.getCurrentExtension();
 const SourceAdapter = Self.imports.sourceAdapter;
@@ -113,34 +117,31 @@ var WallpaperController = class {
 
 		let output_file, output_stream, input_file;
 
-		try {
-			output_file = Gio.file_new_for_path(this.wallpaperlocation + String(name));
-			output_stream = output_file.create(0, null);
+		let _httpSession = new Soup.SessionAsync();
+		Soup.Session.prototype.add_feature.call(_httpSession, new Soup.ProxyResolverDefault());
 
-			input_file = Gio.file_new_for_uri(uri);
-		} catch (e) {
-			if (callback) {
-				callback(null, null, e);
-			}
-			return;
-		}
+		let file = Gio.file_new_for_path(this.wallpaperlocation + String(name));
+		let fstream = file.replace(null, false, Gio.FileCreateFlags.NONE, null);
 
-		input_file.load_contents_async(null, (file, result) => {
-			let contents = null;
-
+		// start the download
+		let request = Soup.Message.new('GET', uri);
+		request.connect('got_chunk', Lang.bind(this, function(message, chunk){
 			try {
-				contents = file.load_contents_finish(result)[1];
-				output_stream.write(contents, null);
+				fstream.write(chunk.get_data(), null, chunk.length);
 			} catch (e) {
 				if (callback) {
 					callback(null, null, e);
 				}
 				return;
 			}
+		}));
 
+		_httpSession.queue_message(request, function(_httpSession, message) {
+			// close the file
+			fstream.close(null);
 			// call callback with the name and the full filepath of the written file as parameter
 			if (callback) {
-				callback(name, output_file.get_path());
+				callback(name, file.get_path());
 			}
 		});
 	}


### PR DESCRIPTION
As I mentioned in #72 the call to `Gio.file_new_for_uri` fails starting in 3.34 as only the `file://` protocol is supported.

For this reason I used the `Soup` HTTP client to download the files and save them on the file system.

I tried it on my Fedora 31 installation and I can now download new wallpapers without the `setcap` call.

Secondly, it seems that the GTK inheritance mechanism became stricter in 3.34 and you have to use `GObject.registerClass` to inherit from GTK components.

Fixes #72 .