### PR TITLE
Auto-fetching "minutes" now ranges from 0 to 59

### DIFF
--- a/randomwallpaper@iflow.space/settings.ui
+++ b/randomwallpaper@iflow.space/settings.ui
@@ -32,7 +32,7 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="duration-minutes">
-    <property name="lower">1</property>
+    <property name="lower">0</property>
     <property name="upper">59</property>
     <property name="value">30</property>
     <property name="step_increment">1</property>


### PR DESCRIPTION
I wanted the ability to set the auto-fetching time to an hourly interval, instead of an hour and X minutes. So I changed the minimum minutes to 0 instead of 1.