### PR TITLE
Migrate from tweens to clutter animations (fixes #92)

### DIFF
--- a/randomwallpaper@iflow.space/elements.js
+++ b/randomwallpaper@iflow.space/elements.js
@@ -236,7 +236,7 @@ class StatusElement {
 
 		this.loadingTweenIn = {
 			opacity: 20,
-			duration: 500,
+			duration: 1500,
 			mode: Clutter.AnimationMode.EASE_IN_OUT_SINE,
 			autoReverse: true,
 			repeatCount: -1
@@ -245,14 +245,11 @@ class StatusElement {
 	}
 
 	startLoading() {
-		this.isLoading = true
 		this.icon.ease(this.loadingTweenIn);
 	}
 
 	stopLoading() {
 		this.icon.remove_all_transitions();
-
-		this.isLoading = false;
 		this.icon.opacity = 255;
 	}
 

--- a/randomwallpaper@iflow.space/elements.js
+++ b/randomwallpaper@iflow.space/elements.js
@@ -1,7 +1,6 @@
 const Lang = imports.lang;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
-const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
 const GdkPixbuf = imports.gi.GdkPixbuf;
 const Clutter = imports.gi.Clutter;
@@ -237,45 +236,23 @@ class StatusElement {
 
 		this.loadingTweenIn = {
 			opacity: 20,
-			time: 2,
-			transition: 'easeInOutSine',
-			onComplete: function () {
-				try {
-					Tweener.addTween(_this.icon, _this.loadingTweenOut);
-				} catch (e) {
-					// swollow (not really important)
-				}
-			}
+			duration: 500,
+			mode: Clutter.AnimationMode.EASE_IN_OUT_SINE,
+			autoReverse: true,
+			repeatCount: -1
 		};
-
-		this.loadingTweenOut = {
-			opacity: 255,
-			time: 1,
-			transition: 'easeInOutSine',
-			onComplete: function () {
-				if (_this.isLoading) {
-					try {
-						Tweener.addTween(_this.icon, _this.loadingTweenIn);
-					} catch (e) {
-						// swollow (not really important)
-					}
-				} else {
-					return false;
-				}
-				return true;
-			}
-		}
 
 	}
 
 	startLoading() {
-		this.isLoading = true;
-		Tweener.addTween(this.icon, this.loadingTweenOut);
+		this.isLoading = true
+		this.icon.ease(this.loadingTweenIn);
 	}
 
 	stopLoading() {
+		this.icon.remove_all_transitions();
+
 		this.isLoading = false;
-		Tweener.removeTweens(this.icon);
 		this.icon.opacity = 255;
 	}
 


### PR DESCRIPTION
Updated to work with the latest GNOME shell (3.38.0), and simplified the code using clutter animations.