### PR TITLE
XDG_CACHE_HOME used for downloading wallpapers

### DIFF
--- a/randomwallpaper@iflow.space/wallpaperController.js
+++ b/randomwallpaper@iflow.space/wallpaperController.js
@@ -20,7 +20,14 @@ var WallpaperController = class {
 
 	constructor() {
 		this.logger = new LoggerModule.Logger('RWG3', 'WallpaperController');
-		this.wallpaperlocation = Self.path + '/wallpapers/';
+		let xdg_cache_home = Mainloop.getenv('XDG_CACHE_HOME')
+		if (!xdg_cache_home)
+		{
+			xdg_cache_home = Mainloop.getenv('HOME') + '/.cache'
+		}
+		this.wallpaperlocation = xdg_cache_home + '/RandomWallpaperGnome3/wallpapers/';
+		let mode = parseInt("0755", 8);
+		Mainloop.mkdir_with_parents(this.wallpaperlocation, mode)
 		this.imageSourceAdapter = null;
 
 		this._autoFetch = {

--- a/randomwallpaper@iflow.space/wallpaperController.js
+++ b/randomwallpaper@iflow.space/wallpaperController.js
@@ -23,10 +23,10 @@ var WallpaperController = class {
 		let xdg_cache_home = Mainloop.getenv('XDG_CACHE_HOME')
 		if (!xdg_cache_home)
 		{
-			xdg_cache_home = Mainloop.getenv('HOME') + '/.cache'
+			xdg_cache_home = `${Mainloop.getenv('HOME')}/.cache`
 		}
-		this.wallpaperlocation = xdg_cache_home + '/RandomWallpaperGnome3/wallpapers/';
-		let mode = parseInt("0755", 8);
+		this.wallpaperlocation = `${xdg_cache_home}/${Self.metadata['uuid']}/wallpapers/`;
+		let mode = parseInt('0755', 8);
 		Mainloop.mkdir_with_parents(this.wallpaperlocation, mode)
 		this.imageSourceAdapter = null;
 

--- a/randomwallpaper@iflow.space/wallpapers/.gitignore
+++ b/randomwallpaper@iflow.space/wallpapers/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitkeep
-!.gitignore


### PR DESCRIPTION
A gnome shell extension could be installed using the distribution package system. In this case, the wallpaper download directory will be under `/usr/share/gnome-shell/extensions` and fetching wallpapers will fail due to permissions error.
This PR brings the usage of $XDG_CACHE_HOME environment variable to set the download directory location: `$XDG_CACHE_HOME/RandomWallpaperGnome3/wallpapers` or if not present `$HOME/.cache/RandomWallpaperGnome3/wallpapers`.