### PR TITLE
fix libsoup to v2.4

### DIFF
--- a/randomwallpaper@iflow.space/sourceAdapter.js
+++ b/randomwallpaper@iflow.space/sourceAdapter.js
@@ -1,6 +1,7 @@
 const Self = imports.misc.extensionUtils.getCurrentExtension();
 
 // network requests
+imports.gi.versions.Soup = '2.4';
 const Soup = imports.gi.Soup;
 
 const RWG_SETTINGS_SCHEMA_UNSPLASH = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.unsplash';

--- a/randomwallpaper@iflow.space/wallpaperController.js
+++ b/randomwallpaper@iflow.space/wallpaperController.js
@@ -4,6 +4,7 @@ const Mainloop = imports.gi.GLib;
 const Gio = imports.gi.Gio;
 
 // HTTP
+imports.gi.versions.Soup = '2.4';
 const Soup = imports.gi.Soup;
 const Lang = imports.lang;
 


### PR DESCRIPTION
Apparently, libsoup recently had their 3.0 release. I'm not really able to find any release announcement, however, the package `libsoup3` is [now in the Arch-Repositories](https://archlinux.org/packages/extra/x86_64/libsoup3/), which got installed on my system with an update. (due to dependant packages)

`libsoup3` [removed](https://gitlab.gnome.org/GNOME/libsoup/-/commit/423572c6ee808abec26e7a57cdf6a948d85c811c) the previously already [deprecated `(Soup)SessionAsync`](https://libsoup.org/libsoup-2.4/libsoup-session-porting.html) in favor of `(Soup)Session`.

In consequence, fetching new wallpapers was no longer possible. This PR fixes the version of `libsoup` to `2.4` which is apparently the latest API version name. This does fix the issue for me.

It might be worth considering porting the extension to the unified `(Soup)Session` API, but my experience with GJS is pretty limited, thus this simple fix.