### PR TITLE
Support Gnome 41

### DIFF
--- a/randomwallpaper@iflow.space/metadata.json
+++ b/randomwallpaper@iflow.space/metadata.json
@@ -1,10 +1,10 @@
 {
-  "shell-version": [ "40", "40.0", "40.1" ],
+  "shell-version": [ "40", "40.0", "40.1", "41" ],
   "uuid": "randomwallpaper@iflow.space",
   "settings-schema": "org.gnome.shell.extensions.space.iflow.randomwallpaper",
   "name": "Random Wallpaper",
   "description": "Fetches a random wallpaper from an online source and sets it as desktop background. \nThe desktop background can be updated periodically or manually.",
-  "version": 26,
-  "semantic-version": "2.6.0",
+  "version": 27,
+  "semantic-version": "2.7.0",
   "url": "https://github.com/ifl0w/RandomWallpaperGnome3"
 }


### PR DESCRIPTION
Confirmed working on Gnome 41 by disabling extension version checks using `gsettings set org.gnome.shell disable-extension-version-validation "true"` and running the current, latest version of this extension provided at https://extensions.gnome.org/extension/1040/random-wallpaper/