### PR TITLE
Add development containers to develop branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "container/x11docker"]
+	path = container/x11docker
+	url = https://github.com/mviereck/x11docker.git

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,94 @@
+# MIT License
+#
+# Copyright (c) 2019 mviereck
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Based on x11docker/gnome
+# https://github.com/mviereck/x11docker
+
+ARG VERSION
+FROM ubuntu:${VERSION}
+ENV LANG en_US.UTF-8
+ENV SHELL=/bin/bash
+
+# cleanup script for use after apt-get
+RUN echo '#! /bin/sh\n\
+env DEBIAN_FRONTEND=noninteractive apt-get autoremove -y\n\
+apt-get clean\n\
+find /var/lib/apt/lists -type f -delete\n\
+find /var/cache -type f -delete\n\
+find /var/log -type f -delete\n\
+exit 0\n\
+' > /cleanup && chmod +x /cleanup
+
+# basics
+RUN apt-get update && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      locales && \
+      echo "$LANG UTF-8" >> /etc/locale.gen && \
+      locale-gen && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      dbus \
+      dbus-x11 \
+      systemd && \
+    /cleanup
+
+# Gnome 3
+RUN apt-get update && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      gnome-session && \
+    /cleanup
+
+# Gnome 3 apps
+RUN apt-get update && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      arandr `#Lightweight utility to set resolution` \
+      gnome-icon-theme \
+      gnome-terminal \
+      nautilus && \
+    /cleanup
+
+# Gnome Shell extensions
+RUN apt-get update && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      gnome-shell-extension-prefs && \
+    /cleanup
+
+# Workaround to get gnome-session running.
+# gnome-session fails if started directly. Running gnome-shell only works, but lacks configuration support.
+RUN apt-get update && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      guake && \
+    rm /usr/share/applications/guake.desktop /usr/share/applications/guake-prefs.desktop && \
+    echo "#! /bin/bash\n\
+guake -e gnome-session\n\
+while pgrep gnome-shell; do sleep 1 ; done\n\
+" >/usr/local/bin/startgnome && \
+    chmod +x /usr/local/bin/startgnome && \
+    /cleanup
+
+# Make sure we already add a user so bind mount won't cause problems later
+RUN adduser --disabled-password --gecos "" dev
+USER dev
+
+# Also prevent the parent directories of the mount to be created and thus owned by root
+RUN mkdir --parents /home/dev/.local/share/gnome-shell/extensions/randomwallpaper@iflow.space
+
+CMD /usr/local/bin/startgnome

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,42 @@
+Development Containers
+=====
+The files in this directory are used to easily test the extension for other GNOME versions without the need for multiple virtual machines or systems. We use [x11docker](https://github.com/mviereck/x11docker) for this which is a bash script which does some preprocessing before finally starting a docker container. Each Docker image is only around 700 MB in size.
+
+## Getting x11docker
+First get x11docker which is included as a submodule in this repository:
+```shell
+git submodule init
+git submodule update --depth=1
+```
+
+## Building desired Docker images
+Currently we use Ubuntu in the images to determine the GNOME version. This version must be provided as a build argument when building the Docker image:
+```shell
+docker build -t gnome38 --build-arg VERSION=21.04 .
+```
+
+The following Ubuntu versions are known to be working:
+
+Ubuntu | GNOME
+------ | -----
+20.04 (LTS) | 3.36.9
+21.04 | 3.38.4
+
+The images are very minimal to keep them small. Only the necessary GNOME components are included.
+
+## Running x11docker
+The script `runx11docker.sh` is provided to start x11docker with the correct parameters. It automatically mounts the extension directory from this repository in the GNOME container. You need to supply the name of your recently build image as argument:
+```shell
+./runx11docker.sh gnome38
+```
+
+**For unknown reasons you have to move the X window around until the container is fully loaded for now.**
+
+The application ARandR is included which can use the change the resolution. You can enable the extension and access the settings window via the Extensions application.
+
+## Testing changes
+You can keep the container running while making changes. Once you've made some changes to the code, be sure to run `build.sh` from the parent directory so `gschemas.compiled` is recreated.
+
+Inside the container you have to restart GNOME. Press CTRL + SHIFT to lock your mouse and keyboard in the X windows so you can use key modifiers. Then restart GNOME by pressing ALT + F2 and running the command `r`. You can use CTRL + SHIFT to release your keyboard and mouse again.
+
+Any debug messages will be displayed in your console, so there is no need to run `debug.sh`.

--- a/container/README.md
+++ b/container/README.md
@@ -42,4 +42,4 @@ You can keep the container running while making changes. Once you've made some c
 
 Inside the container you have to restart GNOME. Press CTRL + SHIFT to lock your mouse and keyboard in the X windows so you can use key modifiers. Then restart GNOME by pressing ALT + F2 and running the command `r`. You can use CTRL + SHIFT to release your keyboard and mouse again.
 
-For some reason filtering as usual in `debug.sh` doesn't work inside the container. You can just run `journalctl -f` inside the container and look for relevant output.
+Any debug messages will be displayed in your console, so there is no need to run `debug.sh`.

--- a/container/README.md
+++ b/container/README.md
@@ -1,6 +1,6 @@
 Development Containers
 =====
-The files in this directory are used to easily test the extension for other GNOME versions without the need for multiple virtual machines or systems. We use [x11docker](https://github.com/mviereck/x11docker) for this which is a bash script which does some preprocessing before finally starting a docker container. Each Docker image is only around 700 MB in size.
+The files in this directory are used to easily test the extension for other GNOME versions without the need for multiple virtual machines or systems. We use [x11docker](https://github.com/mviereck/x11docker) for this which is a bash script which does some preprocessing before finally starting a docker container. Each Docker image is only around 700-900 MB in size depending on the version.
 
 ## Getting x11docker
 First get x11docker which is included as a submodule in this repository:
@@ -21,10 +21,13 @@ Ubuntu | GNOME
 ------ | -----
 20.04 (LTS) | 3.36.9
 21.04 | 3.38.4
+21.10 | 40.5
 
 The images are very minimal to keep them small. Only the necessary GNOME components are included.
 
 ## Running x11docker
+> Some version of Docker have trouble running Ubuntu 21.10. In this case you might have to add `--security-opt seccomp=unconfined` to the `runx11docker.sh` script after the `--mount` parameter. As this reduces the security of the container, this is not added by default.
+
 The script `runx11docker.sh` is provided to start x11docker with the correct parameters. It automatically mounts the extension directory from this repository in the GNOME container. You need to supply the name of your recently build image as argument:
 ```shell
 ./runx11docker.sh gnome38
@@ -39,4 +42,4 @@ You can keep the container running while making changes. Once you've made some c
 
 Inside the container you have to restart GNOME. Press CTRL + SHIFT to lock your mouse and keyboard in the X windows so you can use key modifiers. Then restart GNOME by pressing ALT + F2 and running the command `r`. You can use CTRL + SHIFT to release your keyboard and mouse again.
 
-Any debug messages will be displayed in your console, so there is no need to run `debug.sh`.
+For some reason filtering as usual in `debug.sh` doesn't work inside the container. You can just run `journalctl -f` inside the container and look for relevant output.

--- a/container/runx11docker.sh
+++ b/container/runx11docker.sh
@@ -17,5 +17,6 @@ $SCRIPT_DIR/x11docker/x11docker \
 	--desktop \
 	--init=systemd \
 	--user=RETAIN \
+	--runasuser="journalctl -f &" \
 	-- --mount type=bind,source=$SRC_DIR,target=$DST_DIR,readonly -- \
 	$1

--- a/container/runx11docker.sh
+++ b/container/runx11docker.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+SCRIPT_DIR=$(dirname $(readlink -f $0))
+SRC_DIR=$SCRIPT_DIR/../randomwallpaper@iflow.space
+DST_DIR=/home/dev/.local/share/gnome-shell/extensions/randomwallpaper@iflow.space
+
+if [ -z "$1" ]
+  then
+    echo "$(basename $0): Provide your docker image as an argument"
+    exit 22
+fi
+
+echo "$(basename $0): You might have to move the X window around before GNOME is fully loaded"
+sleep 3
+
+$SCRIPT_DIR/x11docker/x11docker \
+	--desktop \
+	--init=systemd \
+	--user=RETAIN \
+	-- --mount type=bind,source=$SRC_DIR,target=$DST_DIR,readonly -- \
+	$1


### PR DESCRIPTION
Add development containers used in the 'gnome-shell-legacy' branch (#110) to the develop branch as well. Requested in https://github.com/ifl0w/RandomWallpaperGnome3/issues/123#issuecomment-996662199.