### PR TITLE
Fix wrong libsoup version when already loaded

### DIFF
--- a/randomwallpaper@iflow.space/soupBowl.js
+++ b/randomwallpaper@iflow.space/soupBowl.js
@@ -8,6 +8,9 @@ imports.gi.versions.Soup = '3.0';
 
 try {
     const _s = imports.gi.Soup;
+    // If Soup is already loaded, this check isn't enough and we need to verify the version
+    if (_s.get_major_version() === 2)
+        imports.gi.versions.Soup = '2.4';
 } catch (e) {
     imports.gi.versions.Soup = '2.4';
 }


### PR DESCRIPTION
If libsoup is already loaded, the import doesn't fail because it isn't executed. However because it is already loaded, we can check which version we are currently running.

This is just a theory however! **It needs to be confirmed on both a libsoup3-only system and a combined system if it doesn't cause any regression on libsoup3 systems.**

Fixes #123 