### PR TITLE
Adding missing let prefix to dark theme property var

### DIFF
--- a/randomwallpaper@iflow.space/wallpaperController.js
+++ b/randomwallpaper@iflow.space/wallpaperController.js
@@ -227,7 +227,7 @@ var WallpaperController = class {
 			set_prop(property);
 		}
 
-		property = "picture-uri-dark";
+		let property = "picture-uri-dark";
 		if (availableKeys.indexOf(property) !== -1) {
 			set_prop(property);
 		}


### PR DESCRIPTION
Adding missing "let" prefix to dark theme property var into _setPicture UriOfSettingsObject() function