### PR TITLE
Add GNOME 43 to supported shell-version

### DIFF
--- a/randomwallpaper@iflow.space/metadata.json
+++ b/randomwallpaper@iflow.space/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": [ "40", "40.0", "40.1", "41", "42" ],
+  "shell-version": [ "40", "40.0", "40.1", "41", "42", "43" ],
   "uuid": "randomwallpaper@iflow.space",
   "settings-schema": "org.gnome.shell.extensions.space.iflow.randomwallpaper",
   "name": "Random Wallpaper",


### PR DESCRIPTION
Works for me on Ubuntu 22.10.