### PR TITLE
Multiple Sources (Requires #143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,27 @@ Install and try the extension at [extensions.gnome.org](https://extensions.gnome
 * Automatic renewal (Auto-Fetching)
 
 ## Installation (symlink to the repository)
-Clone the repository and run `./install.sh` in the repository folder to make a symbolic link from the extensions folder to the git repository.
+Requires [`blueprint-compiler`](https://repology.org/project/blueprint-compiler/versions) at install and update time.
+
+Clone the repository and run `./build.sh && ./install.sh` in the repository folder to make a symbolic link from the extensions folder to the git repository.
 This installation will depend on the repository folder, so do not delete the cloned folder.
 
-Then open the command prompt (Alt+F2) end enter `r` to restart the gnome session. 
+Then open the command prompt (Alt+F2) end enter `r` to restart the gnome session.
 In the case you are using Wayland, then no restart should be required.
 
 Now you should be able to activate the extension through the gnome-tweak-tool.
 
 __Installing this way has various advantages:__
 * Switching between versions and branches.
-* Updating the extension with `git pull` 
+* Updating the extension with `git pull && ./build.sh`
 
 ## Installation (manually)
+Requires [`blueprint-compiler`](https://repology.org/project/blueprint-compiler/versions) at install and update time.
 
 Clone or download the repository and copy the folder `randomwallpaper@iflow.space` in the repository to `~/.local/share/gnome-shell/extensions/`.
+Run `./build.sh` inside the repository.
 
-Then open the command prompt (Alt+F2) end enter `r` to restart the gnome session. 
+Then open the command prompt (Alt+F2) end enter `r` to restart the gnome session.
 In the case you are using Wayland, then no restart should be required.
 
 Now you should be able to activate the extension through the gnome-tweak-tool.
@@ -50,10 +54,24 @@ If you installed the extension manually you have to delete the extension folder 
 
 ## Debugging
 You can follow the output of the extension with `./debug.sh`. Information should be printed using the existing logger class but can also be printed with `global.log()` (not recommended).
-To debug the `prefs.js` use `./debug.sh perfs`.
+To debug the `prefs.js` use `./debug.sh prefs`.
 
 ## Compiling schemas
 This can be done with the command: `glib-compile-schemas randomwallpaper@iflow.space/schemas/`
+
+## Compiling UI
+Requires [`blueprint-compiler`](https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/).
+Run `./build.sh` to compile ui files.
+
+## Adding predefined sources
+1. Build UI for settings using the [blueprint-compiler](https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/) language in `…/ui/my_source.blp` - see [Workbench](https://apps.gnome.org/app/re.sonny.Workbench/) for a live preview editor.
+    * Add the file to `build.sh`
+1. Create a settings layout to the `…/schemas/….gschema.xml`
+1. Create your logic hooking the settings in a `…/ui/my_source.js`
+1. Add the new source to `…/ui/source_row.js`
+    * As string for the the ComboRow in `…/ui/source_row.blp`
+1. Create a adapter to read the settings and fetching the images and additional information in `…/sourceAdapter.js`
+    * Add your adapter to `…/wallpaperController.js`
 
 ## Support Me
 If you enjoy this extension and want to support the development, then feel free to buy me a coffee. :wink: :coffee:

--- a/randomwallpaper@iflow.space/prefs.js
+++ b/randomwallpaper@iflow.space/prefs.js
@@ -1,108 +1,19 @@
-const Adw = imports.gi.Adw;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
-const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
 const ExtensionUtils = imports.misc.extensionUtils;
 
 const Self = ExtensionUtils.getCurrentExtension();
+const SourceRow = Self.imports.ui.source_row;
+
 const WallpaperController = Self.imports.wallpaperController;
 const LoggerModule = Self.imports.logger;
 
 const RWG_SETTINGS_SCHEMA = 'org.gnome.shell.extensions.space.iflow.randomwallpaper';
-const RWG_SETTINGS_SCHEMA_UNSPLASH = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.unsplash';
-const RWG_SETTINGS_SCHEMA_WALLHAVEN = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.wallhaven';
-const RWG_SETTINGS_SCHEMA_REDDIT = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.reddit';
-const RWG_SETTINGS_SCHEMA_GENERIC_JSON = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.genericJSON';
 
 function init(metaData) {
 	//Convenience.initTranslations();
 }
-
-// https://gitlab.gnome.org/GNOME/gjs/-/blob/master/examples/gtk4-template.js
-const SourceRow = GObject.registerClass({
-	GTypeName: 'SourceRow',
-	Template: GLib.filename_to_uri(Self.path + '/ui/source_row.ui', null),
-	Children: [
-		'source_combo',
-		'source_settings_container',
-		'source_id',
-	]
-}, class SourceRow extends Adw.ExpanderRow {
-	constructor(params = {}) {
-		super(params);
-	}
-});
-
-const UnsplashRow = GObject.registerClass({
-	GTypeName: 'UnsplashRow',
-	Template: GLib.filename_to_uri(Self.path + '/ui/unsplash.ui', null),
-	Children: [
-		'unsplash_keyword',
-		'unsplash_featured_only',
-		'unsplash_image_width',
-		'unsplash_image_height',
-		'unsplash_constraint_type',
-		'unsplash_constraint_value'
-	]
-}, class UnsplashRow extends Adw.PreferencesGroup {
-	constructor(params = {}) {
-		super(params);
-	}
-});
-
-const WallhavenRow = GObject.registerClass({
-	GTypeName: 'WallhavenRow',
-	Template: GLib.filename_to_uri(Self.path + '/ui/wallhaven.ui', null),
-	Children: [
-		'wallhaven_keyword',
-		'wallhaven_api_key',
-		'wallhaven_resolutions',
-		'wallhaven_allow_sfw',
-		'wallhaven_allow_sketchy',
-		'wallhaven_allow_nsfw',
-		'wallhaven_category_general',
-		'wallhaven_category_anime',
-		'wallhaven_category_people'
-	]
-}, class WallhavenRow extends Adw.PreferencesGroup {
-	constructor(params = {}) {
-		super(params);
-	}
-});
-
-const RedditRow = GObject.registerClass({
-	GTypeName: 'RedditRow',
-	Template: GLib.filename_to_uri(Self.path + '/ui/reddit.ui', null),
-	Children: [
-		'reddit_allow_sfw',
-		'reddit_subreddits'
-	]
-}, class RedditRow extends Adw.PreferencesGroup {
-	constructor(params = {}) {
-		super(params);
-	}
-});
-
-const GenericJsonRow = GObject.registerClass({
-	GTypeName: 'GenericJsonRow',
-	Template: GLib.filename_to_uri(Self.path + '/ui/generic_json.ui', null),
-	Children: [
-		'generic_json_domain',
-		'generic_json_request_url',
-		'generic_json_image_path',
-		'generic_json_image_prefix',
-		'generic_json_post_path',
-		'generic_json_post_prefix',
-		'generic_json_author_name_path',
-		'generic_json_author_url_path',
-		'generic_json_author_url_prefix'
-	]
-}, class GenericJsonRow extends Adw.PreferencesGroup {
-	constructor(params = {}) {
-		super(params);
-	}
-});
 
 // https://gjs.guide/extensions/development/preferences.html#preferences-window
 function fillPreferencesWindow(window) {
@@ -115,6 +26,8 @@ var RandomWallpaperSettings = class {
 		this.logger = new LoggerModule.Logger('RWG3', 'RandomWallpaper.Settings');
 
 		this._wallpaperController = null;
+		this._sources = [];
+		this.available_rows = {};
 
 		this._settings = ExtensionUtils.getSettings(RWG_SETTINGS_SCHEMA);
 		this._builder = new Gtk.Builder();
@@ -122,60 +35,13 @@ var RandomWallpaperSettings = class {
 		this._builder.add_from_file(Self.path + '/ui/page_general.ui');
 		this._builder.add_from_file(Self.path + '/ui/page_sources.ui');
 
-		this.source_row = new SourceRow();
-		this._builder.get_object('sources_list').add(this.source_row);
-
-		// Unsplash Settings
-		this._unsplash_settings = ExtensionUtils.getSettings(RWG_SETTINGS_SCHEMA_UNSPLASH);
-		this.unsplashSettings = new UnsplashRow();
-		this.bindUnsplash(this.unsplashSettings);
-
-		// Wallhaven Settings
-		this._wallhaven_settings = ExtensionUtils.getSettings(RWG_SETTINGS_SCHEMA_WALLHAVEN);
-		this.wallhavenSettings = new WallhavenRow();
-		this.bindWallhaven(this.wallhavenSettings);
-
-		// Reddit Settings
-		this._reddit_settings = ExtensionUtils.getSettings(RWG_SETTINGS_SCHEMA_REDDIT);
-		this.redditSettings = new RedditRow();
-		this.bindReddit(this.redditSettings);
-
-		// Generic JSON Settings
-		this._generic_json_settings = ExtensionUtils.getSettings(RWG_SETTINGS_SCHEMA_GENERIC_JSON);
-		this.genericJsonSettings = new GenericJsonRow();
-		this.bindGenericJSON(this.genericJsonSettings);
+		this._loadSources();
 
 		this._toggleAfSliders();
 
 		this._builder.get_object('af_switch').connect('notify::active', function (toggleSwitch) {
 			this._toggleAfSliders();
 		}.bind(this));
-
-		this.source_row.source_combo.connect('changed', (sourceCombo) => {
-			let targetWidget = null;
-			switch (sourceCombo.active) {
-				case 0: // unsplash
-					targetWidget = this.unsplashSettings;
-					break;
-				case 1: // wallhaven
-					targetWidget = this.wallhavenSettings;
-					break;
-				case 2: // reddit
-					targetWidget = this.redditSettings;
-					break;
-				case 3: // generic JSON
-					targetWidget = this.genericJsonSettings;
-					break;
-				default:
-					targetWidget = null;
-					this.logger.error("The selected source has no corresponding widget!")
-					break;
-			}
-
-			if (targetWidget !== null) {
-				this.source_row.source_settings_container.set_child(targetWidget);
-			}
-		});
 
 		this._settings.bind('history-length',
 			this._builder.get_object('history_length'),
@@ -188,11 +54,6 @@ var RandomWallpaperSettings = class {
 		this._settings.bind('hours',
 			this._builder.get_object('duration_hours'),
 			'value',
-			Gio.SettingsBindFlags.DEFAULT);
-		// FIXME: I've changed the gsettings schema to int
-		this._settings.bind('source',
-			this.source_row.source_combo,
-			'active',
 			Gio.SettingsBindFlags.DEFAULT);
 		this._settings.bind('auto-fetch',
 			this._builder.get_object('af_switch'),
@@ -218,8 +79,20 @@ var RandomWallpaperSettings = class {
 		this._wallpaperController = new WallpaperController.WallpaperController(true);
 		this._bindButtons();
 
+		window.connect('close-request', () => {
+			this._saveSources();
+		});
+
 		window.add(this._builder.get_object('page_general'));
 		window.add(this._builder.get_object('page_sources'));
+
+		this._sources.forEach(source => {
+			let new_row = new SourceRow.SourceRow(source);
+			this._builder.get_object('sources_list').add(new_row);
+			this.available_rows[new_row.id] = new_row;
+
+			this._bind_source_row(new_row);
+		});
 	}
 
 	_toggleAfSliders() {
@@ -230,152 +103,6 @@ var RandomWallpaperSettings = class {
 			this._builder.get_object('duration_slider_hours').set_sensitive(false);
 			this._builder.get_object('duration_slider_minutes').set_sensitive(false);
 		}
-	}
-
-	bindUnsplash(widget) {
-		this._unsplash_settings.bind('unsplash-keyword',
-			widget.unsplash_keyword,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._unsplash_settings.bind('unsplash-image-width',
-			widget.unsplash_image_width,
-			'value',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._unsplash_settings.bind('unsplash-image-height',
-			widget.unsplash_image_height,
-			'value',
-			Gio.SettingsBindFlags.DEFAULT);
-
-		const unsplash_featured_only = widget.unsplash_featured_only;
-		const unsplash_constraint_type = widget.unsplash_constraint_type;
-		const unsplash_constraint_value = widget.unsplash_constraint_value;
-
-		this._unsplash_settings.bind('unsplash-featured-only',
-			unsplash_featured_only,
-			'active',
-			Gio.SettingsBindFlags.DEFAULT);
-		// FIXME: I've changed the gsettings schema to int
-		this._unsplash_settings.bind('unsplash-constraint-type',
-			unsplash_constraint_type,
-			'active',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._unsplash_settings.bind('unsplash-constraint-value',
-			unsplash_constraint_value,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-
-		this._unsplashUnconstrained(unsplash_constraint_type, true, unsplash_featured_only);
-		this._unsplashUnconstrained(unsplash_constraint_type, false, unsplash_constraint_value);
-		unsplash_constraint_type.connect('changed', (combo) => {
-			this._unsplashUnconstrained(combo, true, unsplash_featured_only);
-			this._unsplashUnconstrained(combo, false, unsplash_constraint_value);
-
-			unsplash_featured_only.set_active(false);
-		});
-	}
-
-	_unsplashUnconstrained(combobox, enable, targetElement) {
-		// FIXME: I've changed the gsettings schema to int
-		if (combobox.active === 0) {
-			targetElement.set_sensitive(enable);
-		} else {
-			targetElement.set_sensitive(!enable);
-		}
-	}
-
-	bindWallhaven(widget) {
-		this._wallhaven_settings.bind('wallhaven-keyword',
-			widget.wallhaven_keyword,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._wallhaven_settings.bind('wallhaven-api-key',
-			widget.wallhaven_api_key,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._wallhaven_settings.bind('resolutions',
-			widget.wallhaven_resolutions,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-
-		this._wallhaven_settings.bind('category-general',
-			widget.wallhaven_category_general,
-			'active',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._wallhaven_settings.bind('category-anime',
-			widget.wallhaven_category_anime,
-			'active',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._wallhaven_settings.bind('category-people',
-			widget.wallhaven_category_people,
-			'active',
-			Gio.SettingsBindFlags.DEFAULT);
-
-		this._wallhaven_settings.bind('allow-sfw',
-			widget.wallhaven_allow_sfw,
-			'active',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._wallhaven_settings.bind('allow-sketchy',
-			widget.wallhaven_allow_sketchy,
-			'active',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._wallhaven_settings.bind('allow-nsfw',
-			widget.wallhaven_allow_nsfw,
-			'active',
-			Gio.SettingsBindFlags.DEFAULT);
-	}
-
-	bindReddit(widget) {
-		this._reddit_settings.bind('subreddits',
-			widget.reddit_subreddits,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._reddit_settings.bind('allow-sfw',
-			widget.reddit_allow_sfw,
-			'active',
-			Gio.SettingsBindFlags.DEFAULT);
-	}
-
-	bindGenericJSON(widget) {
-		this._generic_json_settings.bind('generic-json-id',
-			this.source_row.source_id,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._generic_json_settings.bind('generic-json-domain',
-			widget.generic_json_domain,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._generic_json_settings.bind('generic-json-request-url',
-			widget.generic_json_request_url,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._generic_json_settings.bind('generic-json-image-path',
-			widget.generic_json_image_path,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._generic_json_settings.bind('generic-json-image-prefix',
-			widget.generic_json_image_prefix,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._generic_json_settings.bind('generic-json-post-path',
-			widget.generic_json_post_path,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._generic_json_settings.bind('generic-json-post-prefix',
-			widget.generic_json_post_prefix,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._generic_json_settings.bind('generic-json-author-name-path',
-			widget.generic_json_author_name_path,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._generic_json_settings.bind('generic-json-author-url-path',
-			widget.generic_json_author_url_path,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
-		this._generic_json_settings.bind('generic-json-author-url-prefix',
-			widget.generic_json_author_url_prefix,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
 	}
 
 	_bindButtons() {
@@ -402,6 +129,73 @@ var RandomWallpaperSettings = class {
 			let uri = GLib.filename_to_uri(this._wallpaperController.wallpaperlocation, "");
 			Gio.AppInfo.launch_default_for_uri(uri, Gio.AppLaunchContext.new());
 		});
+
+		this._builder.get_object('button_new_source').connect('clicked', button => {
+			let source_row = new SourceRow.SourceRow();
+			this.available_rows[source_row.id] = source_row;
+			this._builder.get_object('sources_list').add(source_row);
+
+			this._bind_source_row(source_row);
+		});
 	}
 
+	_bind_source_row(source_row) {
+		source_row.connect('notify::expanded', (row) => {
+			if (!row.expanded) {
+				this._saveSources();
+			}
+		});
+
+		source_row.connect('notify::enable-expansion', (row) => {
+			this._saveSources();
+		});
+
+		source_row.button_delete.connect('clicked', button => {
+			this._builder.get_object('sources_list').remove(source_row);
+			delete this.available_rows[source_row.id];
+			this._saveSources();
+		});
+
+		source_row.combo.connect('notify::selected', comboRow => {
+			this._saveSources();
+		});
+	}
+
+	/**
+	 * Load the config from the gschema
+	 */
+	_loadSources() {
+		let stringSources = this._settings.get_strv('sources');
+		this._sources = stringSources.map(elem => {
+			return JSON.parse(elem)
+		});
+
+		this._sources.sort((a, b) => {
+			return a.type - b.type;
+		});
+	}
+
+	/**
+	 * Save the config to the gschema
+	 */
+	_saveSources() {
+		this._sources = [];
+
+		for (const row in this.available_rows) {
+			if (Object.hasOwnProperty.call(this.available_rows, row)) {
+				const element = this.available_rows[row];
+				this._sources.push({
+					id: element.id,
+					type: element.combo.get_selected(),
+					enabled: element.get_enable_expansion()
+				});
+			}
+		}
+
+		let stringSources = this._sources.map(elem => {
+			return JSON.stringify(elem)
+		});
+		this._settings.set_strv('sources', stringSources);
+		Gio.Settings.sync();
+	}
 };

--- a/randomwallpaper@iflow.space/prefs.js
+++ b/randomwallpaper@iflow.space/prefs.js
@@ -37,12 +37,6 @@ var RandomWallpaperSettings = class {
 
 		this._loadSources();
 
-		this._toggleAfSliders();
-
-		this._builder.get_object('af_switch').connect('notify::active', function (toggleSwitch) {
-			this._toggleAfSliders();
-		}.bind(this));
-
 		this._settings.bind('history-length',
 			this._builder.get_object('history_length'),
 			'value',
@@ -93,16 +87,6 @@ var RandomWallpaperSettings = class {
 
 			this._bind_source_row(new_row);
 		});
-	}
-
-	_toggleAfSliders() {
-		if (this._builder.get_object('af_switch').get_enable_expansion()) {
-			this._builder.get_object('duration_slider_hours').set_sensitive(true);
-			this._builder.get_object('duration_slider_minutes').set_sensitive(true);
-		} else {
-			this._builder.get_object('duration_slider_hours').set_sensitive(false);
-			this._builder.get_object('duration_slider_minutes').set_sensitive(false);
-		}
 	}
 
 	_bindButtons() {

--- a/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
+++ b/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain='gnome-shell-extensions'>
 
-    <enum id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources'>
-        <value value='0' nick='unsplash' />
-        <value value='1' nick='wallhaven' />
-        <value value='2' nick='reddit' />
-        <value value='3' nick='genericJSON' />
-    </enum>
+    <!-- <enum id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources'>
+        <value value='0' nick='unsplash'/>
+        <value value='1' nick='wallhaven'/>
+        <value value='2' nick='reddit'/>
+        <value value='3' nick='genericJSON'/>
+    </enum> -->
 
     <schema path="/org/gnome/shell/extensions/space-iflow-randomwallpaper/"
         id='org.gnome.shell.extensions.space.iflow.randomwallpaper'>
@@ -44,12 +44,6 @@
             <range min='0' max='23' />
         </key>
 
-        <key type='i' name='source'>
-            <default>0</default>
-            <summary>Wallpaper Source</summary>
-            <description>Describes the adapter that will be used.</description>
-        </key>
-
         <key type='as' name='history'>
             <default>[]</default>
             <summary>History</summary>
@@ -59,8 +53,7 @@
         <key type='x' name='timer-last-trigger'>
             <default>0</default>
             <summary>Timestamp of the last timer trigger.</summary>
-            <description>A JS timestamp of the last timer callback trigger. Zero if no last change registered.
-</description>
+            <description>A JS timestamp of the last timer callback trigger. Zero if no last change registered.</description>
         </key>
 
         <key type='b' name='change-lock-screen'>
@@ -81,88 +74,117 @@
             <description>Removes the panel icon from the gnome shell.</description>
         </key>
 
+        <key type='as' name='sources'>
+            <default>[]</default>
+            <summary>Configured Wallpaper Sources</summary>
+            <description>A mapping with available configured wallpaper sources as stringified JSON.</description>
+        </key>
+
     </schema>
 
-    <enum id='org.gnome.shell.extensions.space.iflow.randomwallpaper.unsplash.constraints'>
-        <value value='0' nick='unconstrained' />
-        <value value='1' nick='user' />
-        <value value='2' nick='likes' />
-        <value value='3' nick='collection' />
-    </enum>
+    <!-- <enum id='org.gnome.shell.extensions.space.iflow.randomwallpaper.unsplash.constraints'>
+        <value value='0' nick='unconstrained'/>
+        <value value='1' nick='user'/>
+        <value value='2' nick='likes'/>
+        <value value='3' nick='collection'/>
+    </enum> -->
 
-    <schema path="/org/gnome/shell/extensions/space-iflow-randomwallpaper/unsplash/"
-        id='org.gnome.shell.extensions.space.iflow.randomwallpaper.unsplash'>
-        <key type='s' name='unsplash-keyword'>
+    <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.unsplash'>
+
+        <key type='s' name='name'>
+            <default>"Unsplash"</default>
+            <summary>Name</summary>
+            <description>Name for this source.</description>
+        </key>
+
+        <key type='s' name='keyword'>
             <default>""</default>
             <summary>Keyword</summary>
             <description>The keyword will be used to search images.</description>
         </key>
-        <key type='s' name='unsplash-username'>
+
+        <key type='s' name='username'>
             <default>""</default>
             <summary>Username</summary>
             <description>Only fetch random images of a given user.</description>
         </key>
-        <key type='s' name='unsplash-collections'>
+
+        <key type='s' name='collections'>
             <default>""</default>
             <summary>Collections</summary>
             <description>Only fetch random images from a comma separated list of collections.</description>
         </key>
-        <key type='i' name='unsplash-image-width'>
+
+        <key type='i' name='image-width'>
             <default>1920</default>
             <summary>Image Width</summary>
             <description>The width of the image.</description>
         </key>
-        <key type='i' name='unsplash-image-height'>
+
+        <key type='i' name='image-height'>
             <default>1080</default>
             <summary>Image Width</summary>
             <description>The height of the image.</description>
         </key>
-        <key type='b' name='unsplash-featured-only'>
+
+        <key type='b' name='featured-only'>
             <default>false</default>
             <summary>Featured images only</summary>
-            <description>This results in a smaller wallpaper pool but the images are considered to have higher
-                quality.
-</description>
+            <description>This results in a smaller wallpaper pool but the images are considered to have higher quality.</description>
         </key>
-        <key type='i' name='unsplash-constraint-type'>
+
+        <key type='i' name='constraint-type'>
             <default>0</default>
             <summary>Constraint Type</summary>
             <description>The constraint of the Unsplash Source API.</description>
         </key>
-        <key type='s' name='unsplash-constraint-value'>
+
+        <key type='s' name='constraint-value'>
             <default>""</default>
             <summary>Constraint Value</summary>
             <description>This value should match the constraint type for. Has no effect in the case of an unconstrained search.</description>
         </key>
+
     </schema>
 
-    <schema path="/org/gnome/shell/extensions/space-iflow-randomwallpaper/wallhaven/"
-        id='org.gnome.shell.extensions.space.iflow.randomwallpaper.wallhaven'>
-        <key type='s' name='wallhaven-keyword'>
+    <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.wallhaven'>
+
+        <key type='s' name='name'>
+            <default>"Wallhaven"</default>
+            <summary>Name</summary>
+            <description>Name for this source.</description>
+        </key>
+
+        <key type='s' name='keyword'>
             <default>""</default>
             <summary>Keyword</summary>
             <description>The keyword will be used to search images.</description>
         </key>
-        <key type='s' name='wallhaven-api-key'>
+
+        <key type='s' name='api-key'>
             <default>""</default>
             <summary>Api key</summary>
             <description>The wallheven api key.</description>
         </key>
+
         <key type='s' name='resolutions'>
             <default>"1920x1200, 1920x1080, 2560x1440, 2560x1600, 3840x1080"</default>
             <summary>Resolutions</summary>
             <description>The acceptable resolutions.</description>
         </key>
+
         <key type='b' name='allow-sfw'>
             <default>true</default>
             <summary>SFW</summary>
             <description>Weather safe images are allowed.</description>
         </key>
+
         <key type='b' name='allow-sketchy'>
             <default>false</default>
             <summary>Sketchy</summary>
             <description>Weather sketchy images are allowed.</description>
         </key>
+
         <key type='b' name='allow-nsfw'>
             <default>false</default>
             <summary>NSFW</summary>
@@ -174,84 +196,104 @@
             <summary>Category General</summary>
             <description>Weather the general category should be searched.</description>
         </key>
+
         <key type='b' name='category-anime'>
             <default>true</default>
             <summary>Category Anime</summary>
             <description>Weather the anime category should be searched.</description>
         </key>
+
         <key type='b' name='category-people'>
             <default>true</default>
             <summary>Category People</summary>
             <description>Weather the people category should be searched.</description>
         </key>
+
     </schema>
 
-    <schema path="/org/gnome/shell/extensions/space-iflow-randomwallpaper/reddit/"
-        id='org.gnome.shell.extensions.space.iflow.randomwallpaper.reddit'>
+    <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.reddit'>
+        <key type='s' name='name'>
+            <default>"Reddit"</default>
+            <summary>Name</summary>
+            <description>Name for this source.</description>
+        </key>
+
         <key type='s' name='subreddits'>
             <default>""</default>
             <summary>Subreddits</summary>
             <description>These subreddits will be searched.</description>
         </key>
+
         <key type='b' name='allow-sfw'>
             <default>false</default>
             <summary>SFW</summary>
             <description>Whether safe images are allowed.</description>
         </key>
+
     </schema>
 
-    <schema path="/org/gnome/shell/extensions/space-iflow-randomwallpaper/genericJSON/"
-        id='org.gnome.shell.extensions.space.iflow.randomwallpaper.genericJSON'>
-        <key type='s' name='generic-json-id'>
-            <default>""</default>
-            <summary>Identifier</summary>
-            <description>Identifier for this source.</description>
+    <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.genericJSON'>
+
+        <key type='s' name='name'>
+            <default>"genericJSON"</default>
+            <summary>Name</summary>
+            <description>Name for this source.</description>
         </key>
-        <key type='s' name='generic-json-domain'>
+
+        <key type='s' name='domain'>
             <default>""</default>
             <summary>Website URL</summary>
             <description>Main domain for this source.</description>
         </key>
-        <key type='s' name='generic-json-request-url'>
+
+        <key type='s' name='request-url'>
             <default>""</default>
             <summary>The request URL</summary>
             <description>The URL where the JSON will be requested.</description>
         </key>
-        <key type='s' name='generic-json-image-path'>
+
+        <key type='s' name='image-path'>
             <default>""</default>
             <summary>Image JSON Path</summary>
             <description>The JSON path that describes the picture URL.</description>
         </key>
-        <key type='s' name='generic-json-image-prefix'>
+
+        <key type='s' name='image-prefix'>
             <default>""</default>
             <summary>Image URL prefix</summary>
             <description>This prefix is added to the final image URL.</description>
         </key>
-        <key type='s' name='generic-json-post-path'>
+
+        <key type='s' name='post-path'>
             <default>""</default>
             <summary>Post JSON Path</summary>
             <description>The JSON path that describes the post link.</description>
         </key>
-        <key type='s' name='generic-json-post-prefix'>
+
+        <key type='s' name='post-prefix'>
             <default>""</default>
             <summary>Post URL prefix</summary>
             <description>This prefix is added to the post link.</description>
         </key>
-        <key type='s' name='generic-json-author-name-path'>
+
+        <key type='s' name='author-name-path'>
             <default>""</default>
             <summary>Author name JSON Path</summary>
             <description>The JSON path that describes the author name path.</description>
         </key>
-        <key type='s' name='generic-json-author-url-path'>
+
+        <key type='s' name='author-url-path'>
             <default>""</default>
             <summary>Author link JSON Path</summary>
             <description>The JSON path that describes the author link path.</description>
         </key>
-        <key type='s' name='generic-json-author-url-prefix'>
+
+        <key type='s' name='author-url-prefix'>
             <default>""</default>
             <summary>Author link URL prefix</summary>
             <description>This prefix is added to the final author link.</description>
         </key>
+
     </schema>
 
 </schemalist>

--- a/randomwallpaper@iflow.space/settings.js
+++ b/randomwallpaper@iflow.space/settings.js
@@ -9,8 +9,8 @@ var Settings = class {
 	 * @param [schema]
 	 * @private
 	 */
-	constructor(schema) {
-		this._settings = Utils.getSettings(schema);
+	constructor(schema, path = null) {
+		this._settings = Utils.getSettings(schema, path);
 	}
 
 	observe(key, callback) {

--- a/randomwallpaper@iflow.space/ui/generic_json.blp
+++ b/randomwallpaper@iflow.space/ui/generic_json.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-template GenericJsonRow : Adw.PreferencesGroup {
+template GenericJsonSettingsGroup : Adw.PreferencesGroup {
   // title: _("Source Settings");
   description: _("This feature requires some know how. However, many different wallpaper providers can be used with this generic JSON source.\nYou have to specify an URL to a JSON response and a path to the target image URL within the JSON response.\nYou can also define a prefix that will be added to the image URL.");
 
@@ -21,13 +21,13 @@ template GenericJsonRow : Adw.PreferencesGroup {
   Adw.PreferencesGroup {
     title: _("General");
 
-    Adw.EntryRow generic_json_domain {
+    Adw.EntryRow domain {
       title: _("Domain");
       input-purpose: url;
 
       LinkButton {
         valign: center;
-        // uri: bind text;
+        uri: bind domain.text;
 
         Adw.ButtonContent {
           icon-name: "globe-symbolic";
@@ -39,13 +39,13 @@ template GenericJsonRow : Adw.PreferencesGroup {
       }
     }
 
-    Adw.EntryRow generic_json_request_url {
+    Adw.EntryRow request_url {
       title: _("Request URL");
       input-purpose: url;
 
       LinkButton {
         valign: center;
-        // uri: bind text;
+        uri: bind request_url.text;
 
         Adw.ButtonContent {
           icon-name: "globe-symbolic";
@@ -61,12 +61,12 @@ template GenericJsonRow : Adw.PreferencesGroup {
   Adw.PreferencesGroup {
     title: _("Image");
 
-    Adw.EntryRow generic_json_image_path {
+    Adw.EntryRow image_path {
       title: _("JSON Path");
       input-purpose: free_form;
     }
 
-    Adw.EntryRow generic_json_image_prefix {
+    Adw.EntryRow image_prefix {
       title: _("URL prefix");
       input-purpose: free_form;
     }
@@ -75,12 +75,12 @@ template GenericJsonRow : Adw.PreferencesGroup {
   Adw.PreferencesGroup {
     title: _("Post");
 
-    Adw.EntryRow generic_json_post_path {
+    Adw.EntryRow post_path {
       title: _("JSON Path");
       input-purpose: free_form;
     }
 
-    Adw.EntryRow generic_json_post_prefix {
+    Adw.EntryRow post_prefix {
       title: _("URL Prefix");
       input-purpose: free_form;
     }
@@ -89,17 +89,17 @@ template GenericJsonRow : Adw.PreferencesGroup {
   Adw.PreferencesGroup {
     title: _("Author");
 
-    Adw.EntryRow generic_json_author_name_path {
+    Adw.EntryRow author_name_path {
       title: _("Name JSON Path");
       input-purpose: free_form;
     }
 
-    Adw.EntryRow generic_json_author_url_path {
+    Adw.EntryRow author_url_path {
       title: _("URL JSON Path");
       input-purpose: free_form;
     }
 
-    Adw.EntryRow generic_json_author_url_prefix {
+    Adw.EntryRow author_url_prefix {
       title: _("URL URL prefix");
       input-purpose: free_form;
     }

--- a/randomwallpaper@iflow.space/ui/generic_json.js
+++ b/randomwallpaper@iflow.space/ui/generic_json.js
@@ -1,0 +1,74 @@
+const Adw = imports.gi.Adw;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+
+const Self = ExtensionUtils.getCurrentExtension();
+const Convenience = Self.imports.convenience;
+
+const RWG_SETTINGS_SCHEMA_GENERIC_JSON = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.genericJSON';
+
+var GenericJsonSettingsGroup = GObject.registerClass({
+    GTypeName: 'GenericJsonSettingsGroup',
+    Template: GLib.filename_to_uri(Self.path + '/ui/generic_json.ui', null),
+    InternalChildren: [
+        'author_name_path',
+        'author_url_path',
+        'author_url_prefix',
+        'domain',
+        'image_path',
+        'image_prefix',
+        'post_path',
+        'post_prefix',
+        'request_url'
+    ]
+}, class GenericJsonSettingsGroup extends Adw.PreferencesGroup {
+    constructor(parent_row, params = {}) {
+        super(params);
+
+        const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/genericJSON/${parent_row.id}/`;
+        this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_GENERIC_JSON, path);
+
+        this._settings.bind('name',
+            parent_row.source_name,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('domain',
+            this._domain,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('request-url',
+            this._request_url,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('image-path',
+            this._image_path,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('image-prefix',
+            this._image_prefix,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('post-path',
+            this._post_path,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('post-prefix',
+            this._post_prefix,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('author-name-path',
+            this._author_name_path,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('author-url-path',
+            this._author_url_path,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('author-url-prefix',
+            this._author_url_prefix,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+    }
+});

--- a/randomwallpaper@iflow.space/ui/page_sources.blp
+++ b/randomwallpaper@iflow.space/ui/page_sources.blp
@@ -6,11 +6,9 @@ Adw.PreferencesPage page_sources {
   icon-name: "download-symbolic";
 
   Adw.PreferencesGroup sources_list {
-    title: _("Configured Wallpaper Sources");
+    // title: _("Configured Wallpaper Sources");
 
-    // Placeholder
-    header-suffix: Button {
-      sensitive: false;
+    header-suffix: Button button_new_source {
       styles [
         "suggested-action",
       ]

--- a/randomwallpaper@iflow.space/ui/reddit.blp
+++ b/randomwallpaper@iflow.space/ui/reddit.blp
@@ -1,10 +1,10 @@
 using Gtk 4.0;
 using Adw 1;
 
-template RedditRow : Adw.PreferencesGroup {
-  // title: _("Source Settings");
+template RedditSettingsGroup : Adw.PreferencesGroup {
+  title: _("General");
 
-  Adw.EntryRow reddit_subreddits {
+  Adw.EntryRow subreddits {
     title: _("Subreddits - e.g.: wallpaper, wallpapers, minimalwallpaper");
   }
 
@@ -12,7 +12,7 @@ template RedditRow : Adw.PreferencesGroup {
     title: "SFW";
     subtitle: _("Safe for work");
 
-    Switch reddit_allow_sfw {
+    Switch allow_sfw {
       valign: center;
     }
   }

--- a/randomwallpaper@iflow.space/ui/reddit.js
+++ b/randomwallpaper@iflow.space/ui/reddit.js
@@ -1,0 +1,39 @@
+const Adw = imports.gi.Adw;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+
+const Self = ExtensionUtils.getCurrentExtension();
+const Convenience = Self.imports.convenience;
+
+const RWG_SETTINGS_SCHEMA_REDDIT = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.reddit';
+
+var RedditSettingsGroup = GObject.registerClass({
+    GTypeName: 'RedditSettingsGroup',
+    Template: GLib.filename_to_uri(Self.path + '/ui/reddit.ui', null),
+    InternalChildren: [
+        'allow_sfw',
+        'subreddits'
+    ]
+}, class RedditSettingsGroup extends Adw.PreferencesGroup {
+    constructor(parent_row, params = {}) {
+        super(params);
+
+        const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/reddit/${parent_row.id}/`;
+        this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_REDDIT, path);
+
+        this._settings.bind('name',
+            parent_row.source_name,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('allow-sfw',
+            this._allow_sfw,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('subreddits',
+            this._subreddits,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+    }
+});

--- a/randomwallpaper@iflow.space/ui/source_row.blp
+++ b/randomwallpaper@iflow.space/ui/source_row.blp
@@ -2,101 +2,59 @@ using Gtk 4.0;
 using Adw 1;
 
 template SourceRow : Adw.ExpanderRow {
-  title: bind source_id.text;
-  subtitle: bind enabled.active;
+  title: bind source_name.text;
+  show-enable-switch: true;
 
   Box {
     orientation: vertical;
     spacing: 14;
 
-    Adw.EntryRow source_id {
-      title: _("Identifier - Currently only used for Generic JSON Sources");
-      input-purpose: free_form;
-      text: _("My Source - (1080p)");
-    }
+    Adw.Clamp {
+      Adw.PreferencesGroup {
+        title: _("Meta");
 
-    Adw.ActionRow {
-      title: _("Type");
+        Adw.EntryRow source_name {
+          title: _("Name");
+          input-purpose: free_form;
+          text: _("My Source - (1080p)");
+        }
 
-      ComboBoxText source_combo {
-        valign: center;
-        active: 0;
+        Adw.ComboRow combo {
+          title: _("Type");
 
-        items [
-          "Unsplash",
-          "Wallhaven",
-          "Reddit",
-          _("Generic JSON"),
-        ]
-      }
-    }
+          // Adw.EnumListModel ?
+          model: StringList {
+            strings [
+              "Unsplash",
+              "Wallhaven",
+              "Reddit",
+              _("Generic JSON"),
+            ]
+          };
+        }
 
-    // Don't know how I can connect a change signal to a Adw.ComboRow - nothing works
-    // Adw.ComboRow source_combo {
-    //   title: _("Type");
-    //   use-subtitle: true;
+        Adw.ActionRow {
+          title: _("Delete this source");
 
-    //   model: StringList {
-    //     strings [
-    //       "Unsplash",
-    //       "Wallhaven",
-    //       "Reddit",
-    //       _("Generic JSON"),
-    //     ]
-    //   };
-      // Adw.EnumListModel { ??????
-      //   enum-type: string;
+          Button button_delete {
+            valign: center;
 
-      //   Adw.EnumListItem [
-      //     {
-      //       value: 0;
-      //       nick: "Unsplash";
-      //     }, {
-      //       value: 1;
-      //       nick: "Wallhaven";
-      //     }, {
-      //       value: 2;
-      //       nick: "Reddit";
-      //     }, {
-      //       value: 3;
-      //       nick: _("Generic JSON");
-      //     },
-      //   ]
-      // };
-    // }
+            styles [
+              "destructive-action",
+            ]
 
-    Adw.ActionRow {
-      title: _("Enabled");
-      // Placeholder
-      sensitive: false;
-
-      Switch enabled {
-        valign: center;
-        active: true;
-      }
-    }
-
-    Adw.ActionRow {
-      title: _("Delete this source");
-
-      Button {
-        // Placeholder
-        sensitive: false;
-        valign: center;
-
-        styles [
-          "destructive-action",
-        ]
-
-        Adw.ButtonContent {
-          icon-name: "user-trash-symbolic";
-          valign: center;
+            Adw.ButtonContent {
+              icon-name: "user-trash-symbolic";
+              valign: center;
+            }
+          }
         }
       }
     }
 
-    Adw.Clamp source_settings_container {
-      sensitive: bind enabled.active;
-    }
+    Adw.Clamp settings_container { }
+
+    // FIXME: Additional PreferencesGroup solely for spacing to the next row when expanded
+    Adw.PreferencesGroup { }
   }
 }

--- a/randomwallpaper@iflow.space/ui/source_row.js
+++ b/randomwallpaper@iflow.space/ui/source_row.js
@@ -1,0 +1,83 @@
+const Adw = imports.gi.Adw;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+
+const Self = ExtensionUtils.getCurrentExtension();
+const Convenience = Self.imports.convenience;
+
+const Unsplash = Self.imports.ui.unsplash;
+const Wallhaven = Self.imports.ui.wallhaven;
+const Reddit = Self.imports.ui.reddit;
+const GenericJson = Self.imports.ui.generic_json;
+
+// https://gitlab.gnome.org/GNOME/gjs/-/blob/master/examples/gtk4-template.js
+var SourceRow = GObject.registerClass({
+    GTypeName: 'SourceRow',
+    Template: GLib.filename_to_uri(Self.path + '/ui/source_row.ui', null),
+    Children: [
+        'button_delete',
+        'combo',
+        'source_name'
+    ],
+    InternalChildren: [
+        'settings_container'
+    ]
+}, class SourceRow extends Adw.ExpanderRow {
+    constructor(configObject = null, params = {}) {
+        super(params);
+
+        if (configObject === null) {
+            // New row
+            this.id = Date.now();
+            this.combo.set_selected(0);
+            this.set_enable_expansion(true);
+            this._settings_container.set_child(new Unsplash.UnsplashSettingsGroup(this));
+        } else {
+            // Row from config
+            this.id = configObject.id;
+            this.combo.set_selected(configObject.type);
+            this.set_enable_expansion(configObject.enabled);
+
+            this._fill_row(this.combo.selected);
+        }
+
+        this.combo.connect('notify::selected', comboRow => {
+            this._clear_config()
+            this._fill_row(comboRow.selected);
+        });
+    }
+
+    _clear_config() {
+        // TODO: clear remainder?
+        // this._settings_container.get_child().unbind(this);
+        Gio.Settings.unbind(this.source_name, 'text');
+    }
+
+    _fill_row(type) {
+        let targetWidget = null;
+        switch (type) {
+            case 0: // unsplash
+                targetWidget = new Unsplash.UnsplashSettingsGroup(this);
+                break;
+            case 1: // wallhaven
+                targetWidget = new Wallhaven.WallhavenSettingsGroup(this);
+                break;
+            case 2: // reddit
+                targetWidget = new Reddit.RedditSettingsGroup(this);
+                break;
+            case 3: // generic JSON
+                targetWidget = new GenericJson.GenericJsonSettingsGroup(this);
+                break;
+            default:
+                targetWidget = null;
+                this.logger.error("The selected source has no corresponding widget!")
+                break;
+        }
+
+        if (targetWidget !== null) {
+            this._settings_container.set_child(targetWidget);
+        }
+    }
+});

--- a/randomwallpaper@iflow.space/ui/unsplash.blp
+++ b/randomwallpaper@iflow.space/ui/unsplash.blp
@@ -1,10 +1,10 @@
 using Gtk 4.0;
 using Adw 1;
 
-template UnsplashRow : Adw.PreferencesGroup {
-  // title: _("Source Settings");
+template UnsplashSettingsGroup : Adw.PreferencesGroup {
+  title: _("General");
 
-  Adw.EntryRow unsplash_keyword {
+  Adw.EntryRow keyword {
     title: _("Keywords - Comma seperated");
     input-purpose: free_form;
   }
@@ -13,7 +13,7 @@ template UnsplashRow : Adw.PreferencesGroup {
     title: _("Only Featured Images");
     subtitle: _("This option results in a smaller image pool, but the images are considered to be of higher quality.");
 
-    Switch unsplash_featured_only {
+    Switch featured_only {
       valign: center;
     }
   }
@@ -25,7 +25,7 @@ template UnsplashRow : Adw.PreferencesGroup {
       valign: center;
       numeric: true;
 
-      adjustment: Adjustment unsplash_image_width {
+      adjustment: Adjustment image_width {
         step-increment: 1;
         page-increment: 10;
         lower: 1;
@@ -41,7 +41,7 @@ template UnsplashRow : Adw.PreferencesGroup {
       valign: center;
       numeric: true;
 
-      adjustment: Adjustment unsplash_image_height {
+      adjustment: Adjustment image_height {
         step-increment: 1;
         page-increment: 10;
         lower: 1;
@@ -53,36 +53,21 @@ template UnsplashRow : Adw.PreferencesGroup {
   Adw.PreferencesGroup {
     title: _("Contraint");
 
-    Adw.ActionRow {
+    // TODO: ExpanderRow with switch?
+    // Nested ExpanderRows behave strangely
+    Adw.ComboRow constraint_type {
       title: _("Type");
-
-      ComboBoxText unsplash_constraint_type {
-        valign: center;
-        active: 0;
-
-        items [
+      model: StringList {
+        strings [
           _("Unconstraint"),
           _("User"),
           _("User's Likes"),
           _("Collection ID"),
         ]
-      }
+      };
     }
 
-    // Don't know how I can connect a change signal to a Adw.ComboRow - nothing works
-    // Adw.ComboRow unsplash_constraint_type {
-    //   title: _("Type");
-    //   model: StringList {
-    //     strings [
-    //       _("Unconstraint"),
-    //       _("User"),
-    //       _("User's Likes"),
-    //       _("Collection ID"),
-    //     ]
-    //   };
-    // }
-
-    Adw.EntryRow unsplash_constraint_value {
+    Adw.EntryRow constraint_value {
       title: _("Value");
     }
   }

--- a/randomwallpaper@iflow.space/ui/unsplash.js
+++ b/randomwallpaper@iflow.space/ui/unsplash.js
@@ -1,0 +1,76 @@
+const Adw = imports.gi.Adw;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+
+const Self = ExtensionUtils.getCurrentExtension();
+const Convenience = Self.imports.convenience;
+
+const RWG_SETTINGS_SCHEMA_UNSPLASH = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.unsplash';
+
+var UnsplashSettingsGroup = GObject.registerClass({
+    GTypeName: 'UnsplashSettingsGroup',
+    Template: GLib.filename_to_uri(Self.path + '/ui/unsplash.ui', null),
+    InternalChildren: [
+        'constraint_type',
+        'constraint_value',
+        'featured_only',
+        'image_height',
+        'image_width',
+        'keyword'
+    ]
+}, class UnsplashSettingsGroup extends Adw.PreferencesGroup {
+    constructor(parent_row, params = {}) {
+        super(params);
+
+        const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/unsplash/${parent_row.id}/`;
+        this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_UNSPLASH, path);
+
+        this._settings.bind('name',
+            parent_row.source_name,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('keyword',
+            this._keyword,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('image-width',
+            this._image_width,
+            'value',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('image-height',
+            this._image_height,
+            'value',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('featured-only',
+            this._featured_only,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('constraint-type',
+            this._constraint_type,
+            'selected',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('constraint-value',
+            this._constraint_value,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+
+        this._unsplashUnconstrained(this._constraint_type, true, this._featured_only);
+        this._unsplashUnconstrained(this._constraint_type, false, this._constraint_value);
+        this._constraint_type.connect('notify::selected', (comboRow) => {
+            this._unsplashUnconstrained(comboRow, true, this._featured_only);
+            this._unsplashUnconstrained(comboRow, false, this._constraint_value);
+
+            this._featured_only.set_active(false);
+        });
+    }
+
+    _unsplashUnconstrained(comboRow, enable, targetElement) {
+        if (comboRow.selected === 0) {
+            targetElement.set_sensitive(enable);
+        } else {
+            targetElement.set_sensitive(!enable);
+        }
+    }
+});

--- a/randomwallpaper@iflow.space/ui/wallhaven.blp
+++ b/randomwallpaper@iflow.space/ui/wallhaven.blp
@@ -1,18 +1,18 @@
 using Gtk 4.0;
 using Adw 1;
 
-template WallhavenRow : Adw.PreferencesGroup {
+template WallhavenSettingsGroup : Adw.PreferencesGroup {
   // title: _("Source Settings");
 
   Adw.PreferencesGroup {
     title: _("General");
 
-    Adw.EntryRow wallhaven_keyword {
+    Adw.EntryRow keyword {
       title: _("Keywords - Comma seperated");
       input-purpose: free_form;
     }
 
-    Adw.PasswordEntryRow wallhaven_api_key {
+    Adw.PasswordEntryRow api_key {
       title: _("API key");
       input-purpose: password;
 
@@ -30,7 +30,7 @@ template WallhavenRow : Adw.PreferencesGroup {
       }
     }
 
-    Adw.EntryRow wallhaven_resolutions {
+    Adw.EntryRow resolutions {
       title: _("Resolutions: 1920x1080, 2560x1440");
       input-purpose: free_form;
       text: "";
@@ -44,7 +44,7 @@ template WallhavenRow : Adw.PreferencesGroup {
       title: "SFW";
       subtitle: _("Safe for work");
 
-      Switch wallhaven_allow_sfw {
+      Switch allow_sfw {
         valign: center;
       }
     }
@@ -52,7 +52,7 @@ template WallhavenRow : Adw.PreferencesGroup {
     Adw.ActionRow {
       title: "Sketchy";
 
-      Switch wallhaven_allow_sketchy {
+      Switch allow_sketchy {
         valign: center;
       }
     }
@@ -61,7 +61,7 @@ template WallhavenRow : Adw.PreferencesGroup {
       title: "NSFW";
       subtitle: _("Not safe for work");
 
-      Switch wallhaven_allow_nsfw {
+      Switch allow_nsfw {
         valign: center;
       }
     }
@@ -73,7 +73,7 @@ template WallhavenRow : Adw.PreferencesGroup {
     Adw.ActionRow {
       title: "General";
 
-      Switch wallhaven_category_general {
+      Switch category_general {
         valign: center;
       }
     }
@@ -81,7 +81,7 @@ template WallhavenRow : Adw.PreferencesGroup {
     Adw.ActionRow {
       title: "Anime";
 
-      Switch wallhaven_category_anime {
+      Switch category_anime {
         valign: center;
       }
     }
@@ -89,7 +89,7 @@ template WallhavenRow : Adw.PreferencesGroup {
     Adw.ActionRow {
       title: "People";
 
-      Switch wallhaven_category_people {
+      Switch category_people {
         valign: center;
       }
     }

--- a/randomwallpaper@iflow.space/ui/wallhaven.js
+++ b/randomwallpaper@iflow.space/ui/wallhaven.js
@@ -1,0 +1,74 @@
+const Adw = imports.gi.Adw;
+const ExtensionUtils = imports.misc.extensionUtils;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const GObject = imports.gi.GObject;
+
+const Self = ExtensionUtils.getCurrentExtension();
+const Convenience = Self.imports.convenience;
+
+const RWG_SETTINGS_SCHEMA_WALLHAVEN = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.wallhaven';
+
+var WallhavenSettingsGroup = GObject.registerClass({
+    GTypeName: 'WallhavenSettingsGroup',
+    Template: GLib.filename_to_uri(Self.path + '/ui/wallhaven.ui', null),
+    InternalChildren: [
+        'allow_sfw',
+        'allow_sketchy',
+        'allow_nsfw',
+        'api_key',
+        'category_anime',
+        'category_general',
+        'category_people',
+        'keyword',
+        'resolutions'
+    ]
+}, class WallhavenSettingsGroup extends Adw.PreferencesGroup {
+    constructor(parent_row, params = {}) {
+        super(params);
+
+        const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/wallhaven/${parent_row.id}/`;
+        this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_WALLHAVEN, path);
+
+        this._settings.bind('name',
+            parent_row.source_name,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('keyword',
+            this._keyword,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('api-key',
+            this._api_key,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('resolutions',
+            this._resolutions,
+            'text',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('category-general',
+            this._category_general,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('category-anime',
+            this._category_anime,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('category-people',
+            this._category_people,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('allow-sfw',
+            this._allow_sfw,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('allow-sketchy',
+            this._allow_sketchy,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        this._settings.bind('allow-nsfw',
+            this._allow_nsfw,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
+    }
+});


### PR DESCRIPTION
Multiple sources are now possible and randomly selected. A hidden feature is that the list gets sorted by source type on opening the preferences window.
They're stored each in its own gsettings. Timestamps as IDs remembered for mapping in `/sources`, general settings in `/sources/general/` and specific settings in the respective source subfolders `/sources/${Source}/`.

I'm not sure if I introduced the bug through the rework above, but the timer wasn't starting again after closing the preferences window. ~~This was fixed in e7aa0c4.~~ I'm experiencing that the timer resets after some time.
It seems the cause is that the extension runs in two contexts which can't be caught by the instance/singleton workaround. This might be the same issue behind #135 - there are basically multiple timers and observers to settings changes running in the background.

<details>
<summary>Screenshots</summary>


![Page General](https://user-images.githubusercontent.com/1408843/201074224-6f2775ba-b7eb-42a8-bc50-dc61bf24bc6d.png)
![Page Sources](https://user-images.githubusercontent.com/1408843/201074239-62dbd8f3-01b0-4340-805d-2d7056875315.png)

</details>

This will fix #102 fix #91 fix #57 fix #50 fix #39
This extension works for Gnome 42+ so this will fix #129 fix #133 fix #138