### PR TITLE
Decouple preference window from wallpaperController (Requires #141)

### DIFF
--- a/randomwallpaper@iflow.space/prefs.js
+++ b/randomwallpaper@iflow.space/prefs.js
@@ -29,6 +29,13 @@ function fillPreferencesWindow(window) {
 	new RandomWallpaperSettings(window);
 }
 
+// 40 < Gnome < 42
+// function buildPrefsWidget() {
+// 	let window = new Adw.PreferencesWindow();
+// 	new RandomWallpaperSettings(window);
+// 	return window;
+// }
+
 /* UI Setup */
 var RandomWallpaperSettings = class {
 	_backendConnection = null;

--- a/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
+++ b/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
@@ -82,6 +82,35 @@
 
     </schema>
 
+    <schema path="/org/gnome/shell/extensions/space-iflow-randomwallpaper/backend-connection/"
+        id='org.gnome.shell.extensions.space.iflow.randomwallpaper.backend-connection'>
+
+        <key type='b' name='clear-history'>
+            <default>false</default>
+            <summary>Clear history request</summary>
+            <description>Request clearing the history.</description>
+        </key>
+
+        <key type='b' name='open-folder'>
+            <default>false</default>
+            <summary>Open folder request</summary>
+            <description>Request opening the folder.</description>
+        </key>
+
+        <key type='b' name='pause-timer'>
+            <default>false</default>
+            <summary>Pause the timer</summary>
+            <description>Pause the background timer if running.</description>
+        </key>
+
+        <key type='b' name='request-new-wallpaper'>
+            <default>false</default>
+            <summary>Request a new wallpaper</summary>
+            <description>Manually request a new wallpaper.</description>
+        </key>
+
+    </schema>
+
     <!-- <enum id='org.gnome.shell.extensions.space.iflow.randomwallpaper.unsplash.constraints'>
         <value value='0' nick='unconstrained'/>
         <value value='1' nick='user'/>

--- a/randomwallpaper@iflow.space/wallpaperController.js
+++ b/randomwallpaper@iflow.space/wallpaperController.js
@@ -47,6 +47,14 @@ var WallpaperController = class {
 		this._stopLoadingHooks = [];
 
 		this._backendConnection = new Prefs.Settings(RWG_SETTINGS_SCHEMA_BACKEND_CONNECTION);
+
+		// Bring values to defined stage
+		this._backendConnection.set('clear-history', 'boolean', false);
+		this._backendConnection.set('open-folder', 'boolean', false);
+		this._backendConnection.set('pause-timer', 'boolean', false);
+		this._backendConnection.set('request-new-wallpaper', 'boolean', false);
+
+		// Track value changes
 		this._backendConnection.observe('clear-history', () => this._clearHistory());
 		this._backendConnection.observe('open-folder', () => this._openFolder());
 		this._backendConnection.observe('pause-timer', () => this._pauseTimer());
@@ -103,8 +111,8 @@ var WallpaperController = class {
 			this.update();
 			this.fetchNewWallpaper(() => {
 				this.update();
+				this._backendConnection.set('request-new-wallpaper', 'boolean', false);
 			});
-			this._backendConnection.set('request-new-wallpaper', 'boolean', false);
 		}
 	}
 


### PR DESCRIPTION
I've decoupled the preferences window from all background activity. The background controller now tracks some gsetting changes to communicate with the preferences window. I'm confident this fixes #135 since there's now only one single `wallpaperController` running.

This also fixes #126 - just use your favorite keyboard shortcut manager (like gnomes in settings -> keyboard -> shortcuts -> own shortcuts) to set the variable `request-new-wallpaper` to `true`:
~~~
gsettings --schemadir "${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions/randomwallpaper@iflow.space/schemas" set org.gnome.shell.extensions.space.iflow.randomwallpaper.backend-connection request-new-wallpaper true
~~~