### PR TITLE
Allow running post commands (Requires #147)

### DIFF
--- a/randomwallpaper@iflow.space/adapter/genericJson.js
+++ b/randomwallpaper@iflow.space/adapter/genericJson.js
@@ -8,14 +8,20 @@ const SoupBowl = Self.imports.soupBowl;
 
 const BaseAdapter = Self.imports.adapter.baseAdapter;
 
-const RWG_SETTINGS_SCHEMA_GENERIC_JSON = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.genericJSON';
+const RWG_SETTINGS_SCHEMA_SOURCES_GENERIC_JSON = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.genericJSON';
 
 var GenericJsonAdapter = class extends BaseAdapter.BaseAdapter {
-	constructor(id, wallpaperLocation) {
+	constructor(id, name, wallpaperLocation) {
 		super(wallpaperLocation);
+
+		this._sourceName = name;
+		if (this._sourceName === null || this._sourceName === "") {
+			this._sourceName = 'Generic JSON Source';
+		}
+
 		this._jsonPathParser = new JSONPath.JSONPathParser();
 		let path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/genericJSON/${id}/`;
-		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_GENERIC_JSON, path);
+		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_SOURCES_GENERIC_JSON, path);
 		this.bowl = new SoupBowl.Bowl();
 	}
 
@@ -37,11 +43,6 @@ var GenericJsonAdapter = class extends BaseAdapter.BaseAdapter {
 				let domainUrl = this._settings.get("domain", "string");
 				let authorNameJSONPath = this._settings.get("author-name-path", "string");
 				let authorUrlJSONPath = this._settings.get("author-url-path", "string");
-
-				let identifier = this._settings.get("name", "string");
-				if (identifier === null || identifier === "") {
-					identifier = 'Generic JSON Source';
-				}
 
 				let rObject = this._jsonPathParser.access(response_body, imageJSONPath);
 				let imageDownloadUrl = this._settings.get("image-prefix", "string") + rObject.Object;
@@ -73,7 +74,7 @@ var GenericJsonAdapter = class extends BaseAdapter.BaseAdapter {
 				}
 
 				if (callback) {
-					let historyEntry = new HistoryModule.HistoryEntry(authorName, identifier, imageDownloadUrl);
+					let historyEntry = new HistoryModule.HistoryEntry(authorName, this._sourceName, imageDownloadUrl);
 
 					if (authorUrl !== null && authorUrl !== "") {
 						historyEntry.source.authorUrl = authorUrl;

--- a/randomwallpaper@iflow.space/adapter/localFolder.js
+++ b/randomwallpaper@iflow.space/adapter/localFolder.js
@@ -6,18 +6,23 @@ const HistoryModule = Self.imports.history;
 
 const BaseAdapter = Self.imports.adapter.baseAdapter;
 
-const RWG_SETTINGS_SCHEMA_LOCAL_FOLDER = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.localFolder';
+const RWG_SETTINGS_SCHEMA_SOURCES_LOCAL_FOLDER = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.localFolder';
 
 var LocalFolderAdapter = class extends BaseAdapter.BaseAdapter {
-	constructor(id, wallpaperLocation) {
+	constructor(id, name, wallpaperLocation) {
 		super(wallpaperLocation);
 
+		this._sourceName = name;
+		if (this._sourceName === null || this._sourceName === "") {
+			this._sourceName = 'Local Folder';
+		}
+
 		let path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/localFolder/${id}/`;
-		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_LOCAL_FOLDER, path);
+		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_SOURCES_LOCAL_FOLDER, path);
 	}
 
 	requestRandomImage(callback) {
-		const folder = Gio.file_new_for_path(this._settings.get('folder', 'string'));
+		const folder = Gio.File.new_for_path(this._settings.get('folder', 'string'));
 		let files = this._listDirectory(folder);
 
 		if (files === null || files.length < 1) {
@@ -26,22 +31,17 @@ var LocalFolderAdapter = class extends BaseAdapter.BaseAdapter {
 
 		let randomFile = files[Math.floor(Math.random() * files.length)].get_path();
 
-		let identifier = this._settings.get("name", "string");
-		if (identifier === null || identifier === "") {
-			identifier = 'Local Folder';
-		}
-
 		if (callback) {
-			let historyEntry = new HistoryModule.HistoryEntry(null, identifier, randomFile);
+			let historyEntry = new HistoryModule.HistoryEntry(null, this._sourceName, randomFile);
 			historyEntry.source.sourceUrl = this._wallpaperLocation;
 			callback(historyEntry);
 		}
 	}
 
 	fetchFile(path, callback) {
-		let sourceFile = Gio.file_new_for_path(path);
+		let sourceFile = Gio.File.new_for_path(path);
 		let name = sourceFile.get_basename()
-		let targetFile = Gio.file_new_for_path(this._wallpaperLocation + String(name));
+		let targetFile = Gio.File.new_for_path(this._wallpaperLocation + String(name));
 
 		// https://gjs.guide/guides/gio/file-operations.html#copying-and-moving-files
 		sourceFile.copy(targetFile, Gio.FileCopyFlags.NONE, null, null);

--- a/randomwallpaper@iflow.space/adapter/reddit.js
+++ b/randomwallpaper@iflow.space/adapter/reddit.js
@@ -7,14 +7,19 @@ const SoupBowl = Self.imports.soupBowl;
 
 const BaseAdapter = Self.imports.adapter.baseAdapter;
 
-const RWG_SETTINGS_SCHEMA_REDDIT = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.reddit';
+const RWG_SETTINGS_SCHEMA_SOURCES_REDDIT = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.reddit';
 
 var RedditAdapter = class extends BaseAdapter.BaseAdapter {
-	constructor(id, wallpaperLocation) {
+	constructor(id, name, wallpaperLocation) {
 		super(wallpaperLocation);
 
+		this._sourceName = name;
+		if (this._sourceName === null || this._sourceName === "") {
+			this._sourceName = 'Reddit';
+		}
+
 		let path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/reddit/${id}/`;
-		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_REDDIT, path);
+		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_SOURCES_REDDIT, path);
 		this.bowl = new SoupBowl.Bowl();
 	}
 
@@ -25,10 +30,6 @@ var RedditAdapter = class extends BaseAdapter.BaseAdapter {
 	requestRandomImage(callback) {
 		const subreddits = this._settings.get('subreddits', 'string').split(',').map(s => s.trim()).join('+');
 		const require_sfw = this._settings.get('allow-sfw', 'boolean');
-		let identifier = this._settings.get("name", "string");
-		if (identifier === null || identifier === "") {
-			identifier = 'Reddit';
-		}
 
 		const url = encodeURI('https://www.reddit.com/r/' + subreddits + '.json');
 		let message = this.bowl.Soup.Message.new('GET', url);
@@ -55,7 +56,7 @@ var RedditAdapter = class extends BaseAdapter.BaseAdapter {
 				const imageDownloadUrl = this._ampDecode(submission.preview.images[0].source.url);
 
 				if (callback) {
-					let historyEntry = new HistoryModule.HistoryEntry(null, identifier, imageDownloadUrl);
+					let historyEntry = new HistoryModule.HistoryEntry(null, this._sourceName, imageDownloadUrl);
 					historyEntry.source.sourceUrl = 'https://www.reddit.com/' + submission.subreddit_name_prefixed;
 					historyEntry.source.imageLinkUrl = 'https://www.reddit.com/' + submission.permalink;
 					callback(historyEntry);

--- a/randomwallpaper@iflow.space/adapter/unsplash.js
+++ b/randomwallpaper@iflow.space/adapter/unsplash.js
@@ -5,14 +5,18 @@ const SoupBowl = Self.imports.soupBowl;
 
 const BaseAdapter = Self.imports.adapter.baseAdapter;
 
-const RWG_SETTINGS_SCHEMA_UNSPLASH = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.unsplash';
+const RWG_SETTINGS_SCHEMA_SOURCES_UNSPLASH = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.unsplash';
 
 var UnsplashAdapter = class extends BaseAdapter.BaseAdapter {
-	constructor(id, wallpaperLocation) {
+	constructor(id, name, wallpaperLocation) {
 		super(wallpaperLocation);
 
-		this.sourceName = 'Unsplash';
-		this.sourceUrl = 'https://source.unsplash.com';
+		this._sourceName = name;
+		if (this._sourceName === null || this._sourceName === "") {
+			this._sourceName = 'Unsplash';
+		}
+
+		this._sourceUrl = 'https://source.unsplash.com';
 
 		// query options
 		this.options = {
@@ -29,18 +33,13 @@ var UnsplashAdapter = class extends BaseAdapter.BaseAdapter {
 		}
 
 		let path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/unsplash/${id}/`;
-		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_UNSPLASH, path);
+		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_SOURCES_UNSPLASH, path);
 		this.bowl = new SoupBowl.Bowl();
 	}
 
 	requestRandomImage(callback) {
 		this._readOptionsFromSettings();
 		let optionsString = this._generateOptionsString();
-
-		let identifier = this._settings.get("name", "string");
-		if (identifier === null || identifier === "") {
-			identifier = this.sourceName;
-		}
 
 		let url = `https://source.unsplash.com${optionsString}`;
 		url = encodeURI(url);
@@ -65,8 +64,8 @@ var UnsplashAdapter = class extends BaseAdapter.BaseAdapter {
 
 			imageLinkUrl = message.response_headers.get_one('Location');
 
-			let historyEntry = new HistoryModule.HistoryEntry(null, identifier, imageLinkUrl);
-			historyEntry.source.sourceUrl = this.sourceUrl;
+			let historyEntry = new HistoryModule.HistoryEntry(null, this._sourceName, imageLinkUrl);
+			historyEntry.source.sourceUrl = this._sourceUrl;
 			historyEntry.source.imageLinkUrl = imageLinkUrl;
 			callback(historyEntry);
 		});

--- a/randomwallpaper@iflow.space/adapter/urlSource.js
+++ b/randomwallpaper@iflow.space/adapter/urlSource.js
@@ -5,13 +5,19 @@ const SettingsModule = Self.imports.settings;
 
 const BaseAdapter = Self.imports.adapter.baseAdapter;
 
-const RWG_SETTINGS_SCHEMA_URL_SOURCE = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.urlSource';
+const RWG_SETTINGS_SCHEMA_SOURCES_URL_SOURCE = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.urlSource';
 
 var UrlSourceAdapter = class extends BaseAdapter.BaseAdapter {
-    constructor(id, wallpaperLocation) {
+    constructor(id, name, wallpaperLocation) {
         super(wallpaperLocation);
+
+        this._sourceName = name;
+        if (this._sourceName === null || this._sourceName === "") {
+            this._sourceName = 'Static URL';
+        }
+
         let path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/urlSource/${id}/`;
-        this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_URL_SOURCE, path);
+        this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_SOURCES_URL_SOURCE, path);
     }
 
     requestRandomImage(callback) {
@@ -20,11 +26,6 @@ var UrlSourceAdapter = class extends BaseAdapter.BaseAdapter {
         let authorUrl = this._settings.get("author-url", "string");
         let domainUrl = this._settings.get("domain", "string");
         let postUrl = this._settings.get("domain", "string");
-
-        let identifier = this._settings.get("name", "string");
-        if (identifier === null || identifier === "") {
-            identifier = 'Static URL';
-        }
 
         if (typeof postUrl !== 'string' || !postUrl instanceof String) {
             postUrl = null;
@@ -39,7 +40,7 @@ var UrlSourceAdapter = class extends BaseAdapter.BaseAdapter {
         }
 
         if (callback) {
-            let historyEntry = new HistoryModule.HistoryEntry(authorName, identifier, imageDownloadUrl);
+            let historyEntry = new HistoryModule.HistoryEntry(authorName, this._sourceName, imageDownloadUrl);
 
             if (authorUrl !== null && authorUrl !== "") {
                 historyEntry.source.authorUrl = authorUrl;

--- a/randomwallpaper@iflow.space/adapter/wallhaven.js
+++ b/randomwallpaper@iflow.space/adapter/wallhaven.js
@@ -7,11 +7,16 @@ const SoupBowl = Self.imports.soupBowl;
 
 const BaseAdapter = Self.imports.adapter.baseAdapter;
 
-const RWG_SETTINGS_SCHEMA_WALLHAVEN = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.wallhaven';
+const RWG_SETTINGS_SCHEMA_SOURCES_WALLHAVEN = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.wallhaven';
 
 var WallhavenAdapter = class extends BaseAdapter.BaseAdapter {
-	constructor(id, wallpaperLocation) {
+	constructor(id, name, wallpaperLocation) {
 		super(wallpaperLocation);
+
+		this._sourceName = name;
+		if (this._sourceName === null || this._sourceName === "") {
+			this._sourceName = 'Wallhaven';
+		}
 
 		this.options = {
 			'q': '',
@@ -23,18 +28,13 @@ var WallhavenAdapter = class extends BaseAdapter.BaseAdapter {
 		};
 
 		let path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/wallhaven/${id}/`;
-		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_WALLHAVEN, path);
+		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_SOURCES_WALLHAVEN, path);
 		this.bowl = new SoupBowl.Bowl();
 	}
 
 	requestRandomImage(callback) {
 		this._readOptionsFromSettings();
 		let optionsString = this._generateOptionsString();
-
-		let identifier = this._settings.get("name", "string");
-		if (identifier === null || identifier === "") {
-			identifier = 'Wallhaven';
-		}
 
 		let url = 'https://wallhaven.cc/api/v1/search?' + encodeURI(optionsString);
 		let message = this.bowl.Soup.Message.new('GET', url);
@@ -64,7 +64,7 @@ var WallhavenAdapter = class extends BaseAdapter.BaseAdapter {
 			}
 
 			if (callback) {
-				let historyEntry = new HistoryModule.HistoryEntry(null, identifier, downloadURL);
+				let historyEntry = new HistoryModule.HistoryEntry(null, this._sourceName, downloadURL);
 				historyEntry.source.sourceUrl = 'https://wallhaven.cc/';
 				historyEntry.source.imageLinkUrl = siteURL;
 				callback(historyEntry);

--- a/randomwallpaper@iflow.space/elements.js
+++ b/randomwallpaper@iflow.space/elements.js
@@ -108,7 +108,7 @@ var HistoryElement = GObject.registerClass({
 
 			try {
 				if (!targetFolder.make_directory_with_parents(null)) {
-					this.logger.warning('Could not create directories.');
+					this.logger.warn('Could not create directories.');
 					return;
 				}
 			} catch (error) {
@@ -117,12 +117,12 @@ var HistoryElement = GObject.registerClass({
 
 			try {
 				if (!sourceFile.copy(targetFile, Gio.FileCopyFlags.NONE, null, null)) {
-					this.logger.warning('Failed copying image.');
+					this.logger.warn('Failed copying image.');
 					return;
 				}
 			} catch (error) {
 				if (error === Gio.IOErrorEnum.EXISTS) {
-					this.logger.warning('Image already exists in location.');
+					this.logger.warn('Image already exists in location.');
 					return;
 				}
 			}

--- a/randomwallpaper@iflow.space/prefs.js
+++ b/randomwallpaper@iflow.space/prefs.js
@@ -106,6 +106,7 @@ var RandomWallpaperSettings = class {
 			this._builder.get_object('sources_list').add(sourceRow);
 
 			sourceRow.button_delete.connect('clicked', () => {
+				sourceRow.clearConfig();
 				this._builder.get_object('sources_list').remove(sourceRow);
 				this._removeItemOnce(this._sources, id);
 				this._saveSources();
@@ -149,6 +150,7 @@ var RandomWallpaperSettings = class {
 			this._saveSources();
 
 			sourceRow.button_delete.connect('clicked', () => {
+				sourceRow.clearConfig();
 				sourceRowList.remove(sourceRow);
 				this._removeItemOnce(this._sources, sourceRow.id);
 				this._saveSources();

--- a/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
+++ b/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
@@ -77,13 +77,19 @@
         <key type='as' name='sources'>
             <default>[]</default>
             <summary>Configured Wallpaper Sources</summary>
-            <description>A mapping with available configured wallpaper sources as stringified JSON.</description>
+            <description>All available source IDs as string array.</description>
         </key>
 
         <key type='s' name='favorites-folder'>
             <default>""</default>
             <summary>Favorites Folder</summary>
             <description>Saved images will land in this folder.</description>
+        </key>
+
+        <key type='s' name='general-post-command'>
+            <default>""</default>
+            <summary>General post command</summary>
+            <description>Run a command after setting a wallpaper.</description>
         </key>
 
     </schema>
@@ -124,13 +130,29 @@
         <value value='3' nick='collection'/>
     </enum> -->
 
-    <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.unsplash'>
+    <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.general'>
 
         <key type='s' name='name'>
-            <default>"Unsplash"</default>
+            <default>"MySource"</default>
             <summary>Name</summary>
             <description>Name for this source.</description>
         </key>
+
+        <key type='b' name='enabled'>
+            <default>true</default>
+            <summary>Enabled</summary>
+            <description>Whether this source is enabled.</description>
+        </key>
+
+        <key type='i' name='type'>
+            <default>0</default>
+            <summary>Type</summary>
+            <description>The type of this source.</description>
+        </key>
+
+    </schema>
+
+    <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.unsplash'>
 
         <key type='s' name='keyword'>
             <default>""</default>
@@ -183,12 +205,6 @@
     </schema>
 
     <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.wallhaven'>
-
-        <key type='s' name='name'>
-            <default>"Wallhaven"</default>
-            <summary>Name</summary>
-            <description>Name for this source.</description>
-        </key>
 
         <key type='s' name='keyword'>
             <default>""</default>
@@ -247,11 +263,6 @@
     </schema>
 
     <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.reddit'>
-        <key type='s' name='name'>
-            <default>"Reddit"</default>
-            <summary>Name</summary>
-            <description>Name for this source.</description>
-        </key>
 
         <key type='s' name='subreddits'>
             <default>""</default>
@@ -268,12 +279,6 @@
     </schema>
 
     <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.genericJSON'>
-
-        <key type='s' name='name'>
-            <default>"genericJSON"</default>
-            <summary>Name</summary>
-            <description>Name for this source.</description>
-        </key>
 
         <key type='s' name='domain'>
             <default>""</default>
@@ -333,12 +338,6 @@
 
     <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.localFolder'>
 
-        <key type='s' name='name'>
-            <default>"Local Folder"</default>
-            <summary>Name</summary>
-            <description>Name for this source.</description>
-        </key>
-
         <key type='s' name='folder'>
             <default>""</default>
             <summary>Folder</summary>
@@ -348,12 +347,6 @@
     </schema>
 
     <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.urlSource'>
-
-        <key type='s' name='name'>
-            <default>"Static URL"</default>
-            <summary>Name</summary>
-            <description>Name for this source.</description>
-        </key>
 
         <key type='s' name='image-url'>
             <default>""</default>

--- a/randomwallpaper@iflow.space/ui/genericJson.js
+++ b/randomwallpaper@iflow.space/ui/genericJson.js
@@ -67,4 +67,16 @@ var GenericJsonSettingsGroup = GObject.registerClass({
 			'text',
 			Gio.SettingsBindFlags.DEFAULT);
 	}
+
+	clearConfig() {
+		this._settings.reset('domain');
+		this._settings.reset('request-url');
+		this._settings.reset('image-path');
+		this._settings.reset('image-prefix');
+		this._settings.reset('post-path');
+		this._settings.reset('post-prefix');
+		this._settings.reset('author-name-path');
+		this._settings.reset('author-url-path');
+		this._settings.reset('author-url-prefix');
+	}
 });

--- a/randomwallpaper@iflow.space/ui/genericJson.js
+++ b/randomwallpaper@iflow.space/ui/genericJson.js
@@ -7,7 +7,7 @@ const GObject = imports.gi.GObject;
 const Self = ExtensionUtils.getCurrentExtension();
 const Convenience = Self.imports.convenience;
 
-const RWG_SETTINGS_SCHEMA_GENERIC_JSON = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.genericJSON';
+const RWG_SETTINGS_SCHEMA_SOURCES_GENERIC_JSON = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.genericJSON';
 
 var GenericJsonSettingsGroup = GObject.registerClass({
 	GTypeName: 'GenericJsonSettingsGroup',
@@ -24,16 +24,12 @@ var GenericJsonSettingsGroup = GObject.registerClass({
 		'request_url'
 	]
 }, class GenericJsonSettingsGroup extends Adw.PreferencesGroup {
-	constructor(parent_row, params = {}) {
+	constructor(id, params = {}) {
 		super(params);
 
-		const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/genericJSON/${parent_row.id}/`;
-		this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_GENERIC_JSON, path);
+		const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/genericJSON/${id}/`;
+		this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_SOURCES_GENERIC_JSON, path);
 
-		this._settings.bind('name',
-			parent_row.source_name,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
 		this._settings.bind('domain',
 			this._domain,
 			'text',

--- a/randomwallpaper@iflow.space/ui/localFolder.js
+++ b/randomwallpaper@iflow.space/ui/localFolder.js
@@ -8,7 +8,7 @@ const Gtk = imports.gi.Gtk;
 const Self = ExtensionUtils.getCurrentExtension();
 const Convenience = Self.imports.convenience;
 
-const RWG_SETTINGS_SCHEMA_LOCAL_FOLDER = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.localFolder';
+const RWG_SETTINGS_SCHEMA_SOURCES_LOCAL_FOLDER = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.localFolder';
 
 var LocalFolderSettingsGroup = GObject.registerClass({
 	GTypeName: 'LocalFolderSettingsGroup',
@@ -20,16 +20,11 @@ var LocalFolderSettingsGroup = GObject.registerClass({
 }, class LocalFolderSettingsGroup extends Adw.PreferencesGroup {
 	_saveDialog = null;
 
-	constructor(parent_row, params = {}) {
+	constructor(id, params = {}) {
 		super(params);
 
-		const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/localFolder/${parent_row.id}/`;
-		this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_LOCAL_FOLDER, path);
-
-		this._settings.bind('name',
-			parent_row.source_name,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
+		const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/localFolder/${id}/`;
+		this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_SOURCES_LOCAL_FOLDER, path);
 
 		this._settings.bind('folder',
 			this._folder_row,

--- a/randomwallpaper@iflow.space/ui/localFolder.js
+++ b/randomwallpaper@iflow.space/ui/localFolder.js
@@ -55,4 +55,8 @@ var LocalFolderSettingsGroup = GObject.registerClass({
 			this._saveDialog.show();
 		});
 	}
+
+	clearConfig() {
+		this._settings.reset('folder');
+	}
 });

--- a/randomwallpaper@iflow.space/ui/pageGeneral.blp
+++ b/randomwallpaper@iflow.space/ui/pageGeneral.blp
@@ -52,6 +52,10 @@ Adw.PreferencesPage page_general {
         valign: center;
       }
     }
+
+    Adw.EntryRow general_post_command {
+      title: _("Run post-command - available variables: %wallpaper_path%");
+    }
   }
 
   Adw.PreferencesGroup {

--- a/randomwallpaper@iflow.space/ui/reddit.js
+++ b/randomwallpaper@iflow.space/ui/reddit.js
@@ -32,4 +32,9 @@ var RedditSettingsGroup = GObject.registerClass({
 			'text',
 			Gio.SettingsBindFlags.DEFAULT);
 	}
+
+	clearConfig() {
+		this._settings.reset('allow-sfw');
+		this._settings.reset('subreddits');
+	}
 });

--- a/randomwallpaper@iflow.space/ui/reddit.js
+++ b/randomwallpaper@iflow.space/ui/reddit.js
@@ -7,7 +7,7 @@ const GObject = imports.gi.GObject;
 const Self = ExtensionUtils.getCurrentExtension();
 const Convenience = Self.imports.convenience;
 
-const RWG_SETTINGS_SCHEMA_REDDIT = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.reddit';
+const RWG_SETTINGS_SCHEMA_SOURCES_REDDIT = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.reddit';
 
 var RedditSettingsGroup = GObject.registerClass({
 	GTypeName: 'RedditSettingsGroup',
@@ -17,16 +17,12 @@ var RedditSettingsGroup = GObject.registerClass({
 		'subreddits'
 	]
 }, class RedditSettingsGroup extends Adw.PreferencesGroup {
-	constructor(parent_row, params = {}) {
+	constructor(id, params = {}) {
 		super(params);
 
-		const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/reddit/${parent_row.id}/`;
-		this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_REDDIT, path);
+		const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/reddit/${id}/`;
+		this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_SOURCES_REDDIT, path);
 
-		this._settings.bind('name',
-			parent_row.source_name,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
 		this._settings.bind('allow-sfw',
 			this._allow_sfw,
 			'active',

--- a/randomwallpaper@iflow.space/ui/sourceRow.js
+++ b/randomwallpaper@iflow.space/ui/sourceRow.js
@@ -63,7 +63,14 @@ var SourceRow = GObject.registerClass({
 	}
 
 	_fillRow(type) {
-		let targetWidget = null;
+		let targetWidget = this._getSettingsGroup(type);
+		if (targetWidget !== null) {
+			this._settings_container.set_child(targetWidget);
+		}
+	}
+
+	_getSettingsGroup(type = 0) {
+		let targetWidget;
 		switch (type) {
 			case 0: // unsplash
 				targetWidget = new Unsplash.UnsplashSettingsGroup(this.id);
@@ -88,9 +95,17 @@ var SourceRow = GObject.registerClass({
 				this.logger.error("The selected source has no corresponding widget!")
 				break;
 		}
+		return targetWidget;
+	}
 
-		if (targetWidget !== null) {
-			this._settings_container.set_child(targetWidget);
+	clearConfig() {
+		for (const i of Array(6).keys()) {
+			let widget = this._getSettingsGroup(i);
+			widget.clearConfig();
 		}
+
+		this._settings.reset('name');
+		this._settings.reset('enabled');
+		this._settings.reset('type');
 	}
 });

--- a/randomwallpaper@iflow.space/ui/unsplash.js
+++ b/randomwallpaper@iflow.space/ui/unsplash.js
@@ -7,7 +7,7 @@ const GObject = imports.gi.GObject;
 const Self = ExtensionUtils.getCurrentExtension();
 const Convenience = Self.imports.convenience;
 
-const RWG_SETTINGS_SCHEMA_UNSPLASH = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.unsplash';
+const RWG_SETTINGS_SCHEMA_SOURCES_UNSPLASH = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.unsplash';
 
 var UnsplashSettingsGroup = GObject.registerClass({
 	GTypeName: 'UnsplashSettingsGroup',
@@ -21,16 +21,12 @@ var UnsplashSettingsGroup = GObject.registerClass({
 		'keyword'
 	]
 }, class UnsplashSettingsGroup extends Adw.PreferencesGroup {
-	constructor(parent_row, params = {}) {
+	constructor(id, params = {}) {
 		super(params);
 
-		const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/unsplash/${parent_row.id}/`;
-		this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_UNSPLASH, path);
+		const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/unsplash/${id}/`;
+		this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_SOURCES_UNSPLASH, path);
 
-		this._settings.bind('name',
-			parent_row.source_name,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
 		this._settings.bind('keyword',
 			this._keyword,
 			'text',

--- a/randomwallpaper@iflow.space/ui/unsplash.js
+++ b/randomwallpaper@iflow.space/ui/unsplash.js
@@ -69,4 +69,13 @@ var UnsplashSettingsGroup = GObject.registerClass({
 			targetElement.set_sensitive(!enable);
 		}
 	}
+
+	clearConfig() {
+		this._settings.reset('keyword');
+		this._settings.reset('image-width');
+		this._settings.reset('image-height');
+		this._settings.reset('featured-only');
+		this._settings.reset('constraint-type');
+		this._settings.reset('constraint-value');
+	}
 });

--- a/randomwallpaper@iflow.space/ui/urlSource.js
+++ b/randomwallpaper@iflow.space/ui/urlSource.js
@@ -47,4 +47,12 @@ var UrlSourceSettingsGroup = GObject.registerClass({
             'text',
             Gio.SettingsBindFlags.DEFAULT);
     }
+
+    clearConfig() {
+        this._settings.reset('author-name');
+        this._settings.reset('author-url');
+        this._settings.reset('domain');
+        this._settings.reset('image-url');
+        this._settings.reset('post-url');
+    }
 });

--- a/randomwallpaper@iflow.space/ui/urlSource.js
+++ b/randomwallpaper@iflow.space/ui/urlSource.js
@@ -7,7 +7,7 @@ const GObject = imports.gi.GObject;
 const Self = ExtensionUtils.getCurrentExtension();
 const Convenience = Self.imports.convenience;
 
-const RWG_SETTINGS_SCHEMA_LOCAL_FOLDER = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.urlSource';
+const RWG_SETTINGS_SCHEMA_SOURCES_URL_SOURCE = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.urlSource';
 
 var UrlSourceSettingsGroup = GObject.registerClass({
     GTypeName: 'UrlSourceSettingsGroup',
@@ -20,16 +20,11 @@ var UrlSourceSettingsGroup = GObject.registerClass({
         'post_url',
     ]
 }, class UrlSourceSettingsGroup extends Adw.PreferencesGroup {
-    constructor(parent_row, params = {}) {
+    constructor(id, params = {}) {
         super(params);
 
-        const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/urlSource/${parent_row.id}/`;
-        this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_LOCAL_FOLDER, path);
-
-        this._settings.bind('name',
-            parent_row.source_name,
-            'text',
-            Gio.SettingsBindFlags.DEFAULT);
+        const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/urlSource/${id}/`;
+        this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_SOURCES_URL_SOURCE, path);
 
         this._settings.bind('author-name',
             this._author_name,

--- a/randomwallpaper@iflow.space/ui/wallhaven.js
+++ b/randomwallpaper@iflow.space/ui/wallhaven.js
@@ -7,7 +7,7 @@ const GObject = imports.gi.GObject;
 const Self = ExtensionUtils.getCurrentExtension();
 const Convenience = Self.imports.convenience;
 
-const RWG_SETTINGS_SCHEMA_WALLHAVEN = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.wallhaven';
+const RWG_SETTINGS_SCHEMA_SOURCES_WALLHAVEN = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.wallhaven';
 
 var WallhavenSettingsGroup = GObject.registerClass({
 	GTypeName: 'WallhavenSettingsGroup',
@@ -24,16 +24,12 @@ var WallhavenSettingsGroup = GObject.registerClass({
 		'resolutions'
 	]
 }, class WallhavenSettingsGroup extends Adw.PreferencesGroup {
-	constructor(parent_row, params = {}) {
+	constructor(id, params = {}) {
 		super(params);
 
-		const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/wallhaven/${parent_row.id}/`;
-		this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_WALLHAVEN, path);
+		const path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/wallhaven/${id}/`;
+		this._settings = Convenience.getSettings(RWG_SETTINGS_SCHEMA_SOURCES_WALLHAVEN, path);
 
-		this._settings.bind('name',
-			parent_row.source_name,
-			'text',
-			Gio.SettingsBindFlags.DEFAULT);
 		this._settings.bind('keyword',
 			this._keyword,
 			'text',

--- a/randomwallpaper@iflow.space/ui/wallhaven.js
+++ b/randomwallpaper@iflow.space/ui/wallhaven.js
@@ -67,4 +67,16 @@ var WallhavenSettingsGroup = GObject.registerClass({
 			'active',
 			Gio.SettingsBindFlags.DEFAULT);
 	}
+
+	clearConfig() {
+		this._settings.reset('keyword');
+		this._settings.reset('api-key');
+		this._settings.reset('resolutions');
+		this._settings.reset('category-anime');
+		this._settings.reset('category-general');
+		this._settings.reset('category-people');
+		this._settings.reset('allow-sfw');
+		this._settings.reset('allow-sketchy');
+		this._settings.reset('allow-nsfw');
+	}
 });


### PR DESCRIPTION
It's now possible to define a command that will run after setting a wallpaper.
This is particular interesting as [Gradience](https://github.com/GradienceTeam/Gradience) is currently implementing a CLI-Interface which can color GTK4/Libadwaita themes based on an image. `gradience monet %wallpaper_path%`
This fixes #128 

* https://github.com/GradienceTeam/Gradience/pull/675
* https://github.com/GradienceTeam/Gradience/issues/671