### PR TITLE
Allow blocking images (Requires #148)

### DIFF
--- a/randomwallpaper@iflow.space/adapter/urlSource.js
+++ b/randomwallpaper@iflow.space/adapter/urlSource.js
@@ -8,53 +8,52 @@ const BaseAdapter = Self.imports.adapter.baseAdapter;
 const RWG_SETTINGS_SCHEMA_SOURCES_URL_SOURCE = 'org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.urlSource';
 
 var UrlSourceAdapter = class extends BaseAdapter.BaseAdapter {
-    constructor(id, name, wallpaperLocation) {
-        super(wallpaperLocation);
+	constructor(id, name, wallpaperLocation) {
+		super({
+			id: id,
+			schemaID: RWG_SETTINGS_SCHEMA_SOURCES_URL_SOURCE,
+			schemaPath: `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/urlSource/${id}/`,
+			wallpaperLocation: wallpaperLocation,
+			name: name,
+			defaultName: 'Static URL'
+		});
+	}
 
-        this._sourceName = name;
-        if (this._sourceName === null || this._sourceName === "") {
-            this._sourceName = 'Static URL';
-        }
+	requestRandomImage(callback) {
+		let imageDownloadUrl = this._settings.get("image-url", "string");
+		let authorName = this._settings.get("author-name", "string");
+		let authorUrl = this._settings.get("author-url", "string");
+		let domainUrl = this._settings.get("domain", "string");
+		let postUrl = this._settings.get("domain", "string");
 
-        let path = `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/urlSource/${id}/`;
-        this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_SOURCES_URL_SOURCE, path);
-    }
+		if (typeof postUrl !== 'string' || !postUrl instanceof String) {
+			postUrl = null;
+		}
 
-    requestRandomImage(callback) {
-        let imageDownloadUrl = this._settings.get("image-url", "string");
-        let authorName = this._settings.get("author-name", "string");
-        let authorUrl = this._settings.get("author-url", "string");
-        let domainUrl = this._settings.get("domain", "string");
-        let postUrl = this._settings.get("domain", "string");
+		if (typeof authorName !== 'string' || !authorName instanceof String) {
+			authorName = null;
+		}
 
-        if (typeof postUrl !== 'string' || !postUrl instanceof String) {
-            postUrl = null;
-        }
+		if (typeof authorUrl !== 'string' || !authorUrl instanceof String) {
+			authorUrl = null;
+		}
 
-        if (typeof authorName !== 'string' || !authorName instanceof String) {
-            authorName = null;
-        }
+		if (callback) {
+			let historyEntry = new HistoryModule.HistoryEntry(authorName, this._sourceName, imageDownloadUrl);
 
-        if (typeof authorUrl !== 'string' || !authorUrl instanceof String) {
-            authorUrl = null;
-        }
+			if (authorUrl !== null && authorUrl !== "") {
+				historyEntry.source.authorUrl = authorUrl;
+			}
 
-        if (callback) {
-            let historyEntry = new HistoryModule.HistoryEntry(authorName, this._sourceName, imageDownloadUrl);
+			if (postUrl !== null && postUrl !== "") {
+				historyEntry.source.imageLinkUrl = postUrl;
+			}
 
-            if (authorUrl !== null && authorUrl !== "") {
-                historyEntry.source.authorUrl = authorUrl;
-            }
+			if (domainUrl !== null && domainUrl !== "") {
+				historyEntry.source.sourceUrl = domainUrl;
+			}
 
-            if (postUrl !== null && postUrl !== "") {
-                historyEntry.source.imageLinkUrl = postUrl;
-            }
-
-            if (domainUrl !== null && domainUrl !== "") {
-                historyEntry.source.sourceUrl = domainUrl;
-            }
-
-            callback(historyEntry);
-        }
-    }
+			callback(historyEntry);
+		}
+	}
 };

--- a/randomwallpaper@iflow.space/history.js
+++ b/randomwallpaper@iflow.space/history.js
@@ -14,6 +14,10 @@ var HistoryEntry = class {
 		this.path = null;
 		this.source = null;
 		this.timestamp = new Date().getTime();
+		this.adapter = {
+			id: null,
+			type: null
+		};
 
 		this.source = {
 			author: author,

--- a/randomwallpaper@iflow.space/prefs.js
+++ b/randomwallpaper@iflow.space/prefs.js
@@ -28,6 +28,7 @@ function init(metaData) {
 // https://gjs.guide/extensions/development/preferences.html#preferences-window
 // Gnome 42+
 function fillPreferencesWindow(window) {
+	window.set_default_size(-1, 720);
 	new RandomWallpaperSettings(window);
 }
 

--- a/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
+++ b/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
@@ -150,6 +150,12 @@
             <description>The type of this source.</description>
         </key>
 
+        <key type='as' name='blocked-images'>
+            <default>[]</default>
+            <summary>Blocked Images</summary>
+            <description>An array of strings containing the filenames of blocked images.</description>
+        </key>
+
     </schema>
 
     <schema id='org.gnome.shell.extensions.space.iflow.randomwallpaper.sources.unsplash'>

--- a/randomwallpaper@iflow.space/ui/sourceRow.blp
+++ b/randomwallpaper@iflow.space/ui/sourceRow.blp
@@ -66,6 +66,11 @@ template SourceRow : Adw.ExpanderRow {
             }
           }
         }
+
+        Adw.ExpanderRow blocked_images_list {
+          title: _("Blocked Images");
+          sensitive: false;
+        }
       }
     }
 


### PR DESCRIPTION
Blocking images is now possible. Blocking happens on filename matches. If an image is blocked another try is given - up to 5 times. Blocking is individual for every configured source. ~~There's currently no UI for unblocking images. To unblock an image remove the string from the array at `/org/gnome/shell/extensions/space-iflow-randomwallpaper/sources/general/${ID}/blocked-images` with dconf.~~
This fixes #139 