### PR TITLE
Hydrapaper and separate lock screen wallpaper (Requires #152)

### DIFF
--- a/randomwallpaper@iflow.space/adapter/genericJson.js
+++ b/randomwallpaper@iflow.space/adapter/genericJson.js
@@ -19,7 +19,6 @@ var GenericJsonAdapter = class extends BaseAdapter.BaseAdapter {
 			defaultName: 'Generic JSON Source'
 		});
 
-		this._jsonPathParser = new JSONPath.JSONPathParser();
 		this.bowl = new SoupBowl.Bowl();
 	}
 
@@ -46,7 +45,7 @@ var GenericJsonAdapter = class extends BaseAdapter.BaseAdapter {
 					let rObject;
 					let imageDownloadUrl;
 					for (let i = 0; i < 5; i++) {
-						rObject = this._jsonPathParser.access(response_body, imageJSONPath);
+						rObject = JSONPath.JSONPathParser.access(response_body, imageJSONPath);
 						imageDownloadUrl = this._settings.get("image-prefix", "string") + rObject.Object;
 
 						let imageBlocked = this._isImageBlocked(this.fileName(imageDownloadUrl));
@@ -77,18 +76,18 @@ var GenericJsonAdapter = class extends BaseAdapter.BaseAdapter {
 					let occurrences = (samePath.match(/@random/g) || []).length;
 					let slicedRandomElements = rObject.RandomElements.slice(0, occurrences);
 
-					let postUrl = this._jsonPathParser.access(response_body, postJSONPath, slicedRandomElements, false).Object;
+					let postUrl = JSONPath.JSONPathParser.access(response_body, postJSONPath, slicedRandomElements, false).Object;
 					postUrl = this._settings.get("post-prefix", "string") + postUrl;
 					if (typeof postUrl !== 'string' || !postUrl instanceof String) {
 						postUrl = null;
 					}
 
-					let authorName = this._jsonPathParser.access(response_body, authorNameJSONPath, slicedRandomElements, false).Object;
+					let authorName = JSONPath.JSONPathParser.access(response_body, authorNameJSONPath, slicedRandomElements, false).Object;
 					if (typeof authorName !== 'string' || !authorName instanceof String) {
 						authorName = null;
 					}
 
-					let authorUrl = this._jsonPathParser.access(response_body, authorUrlJSONPath, slicedRandomElements, false).Object;
+					let authorUrl = JSONPath.JSONPathParser.access(response_body, authorUrlJSONPath, slicedRandomElements, false).Object;
 					authorUrl = this._settings.get("author-url-prefix", "string") + authorUrl;
 					if (typeof authorUrl !== 'string' || !authorUrl instanceof String) {
 						authorUrl = null;

--- a/randomwallpaper@iflow.space/adapter/wallhaven.js
+++ b/randomwallpaper@iflow.space/adapter/wallhaven.js
@@ -45,11 +45,14 @@ var WallhavenAdapter = class extends BaseAdapter.BaseAdapter {
 		this.bowl.send_and_receive(message, (response_body_bytes) => {
 			const response_body = ByteArray.toString(response_body_bytes);
 
-			let response = JSON.parse(response_body).data;
-
-			if (!response || response.length === 0) {
-				this._error("Failed to request image.", callback);
-				return;
+			let response = null;
+			try {
+				response = JSON.parse(response_body).data;
+			} finally {
+				if (!response || response.length === 0) {
+					this._error("Failed to request image.", callback);
+					return;
+				}
 			}
 
 			let downloadURL;

--- a/randomwallpaper@iflow.space/history.js
+++ b/randomwallpaper@iflow.space/history.js
@@ -3,6 +3,7 @@ const Gio = imports.gi.Gio;
 
 const Self = imports.misc.extensionUtils.getCurrentExtension();
 const Prefs = Self.imports.settings;
+const Utils = Self.imports.utils;
 
 const LoggerModule = Self.imports.logger;
 
@@ -82,6 +83,14 @@ var HistoryController = class {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Get a random HistoryEntry.
+	 * @returns {HistoryEntry}
+	 */
+	getRandom() {
+		return this.history[Utils.Utils.getRandomNumber(this.history.length)];
 	}
 
 	/**

--- a/randomwallpaper@iflow.space/history.js
+++ b/randomwallpaper@iflow.space/history.js
@@ -86,6 +86,14 @@ var HistoryController = class {
 	}
 
 	/**
+	 * Get the current history element.
+	 * @returns {HistoryElement}
+	 */
+	getCurrentElement() {
+		return this.history[0];
+	}
+
+	/**
 	 * Get a random HistoryEntry.
 	 * @returns {HistoryEntry}
 	 */

--- a/randomwallpaper@iflow.space/hydraPaper.js
+++ b/randomwallpaper@iflow.space/hydraPaper.js
@@ -1,0 +1,88 @@
+const Gio = imports.gi.Gio;
+
+const Self = imports.misc.extensionUtils.getCurrentExtension();
+const Utils = Self.imports.utils;
+
+var HydraPaper = class {
+	#hydraPaperCommand = null;
+	#hydraPaperCancellable = null;
+
+	constructor() { }
+
+	/**
+	 * Check whether HydraPaper is available on this system.
+	 * @returns {boolean} - Whether HydraPaper is available
+	 */
+	async isAvailable() {
+		if (this.#hydraPaperCommand !== null) {
+			return true;
+		}
+
+		try {
+			// Normal installation:
+			await Utils.Utils.execCheck(['hydrapaper', '--help']);
+
+			this.#hydraPaperCommand = ['hydrapaper'];
+			return true;
+		} catch (error) {
+			// logError(error);
+		}
+
+		try {
+			// FlatPak installation:
+			await Utils.Utils.execCheck(['org.gabmus.hydrapaper', '--help']);
+
+			this.#hydraPaperCommand = ['org.gabmus.hydrapaper'];
+			return true;
+		} catch (error) {
+			// logError(error);
+		}
+
+		return this.#hydraPaperCommand !== null;
+	}
+
+	/**
+	 * Cancel all running processes
+	 * @returns
+	 */
+	cancelRunning() {
+		if (this.#hydraPaperCancellable === null) {
+			return;
+		}
+
+		this.#hydraPaperCancellable.cancel();
+		this.#hydraPaperCancellable = null;
+	}
+
+	/**
+	 * Generate a new combined wallpaper from multiple paths.
+	 *
+	 * @param {Array<string>} wallpaperArray Array of wallpaper paths matching the monitor count
+	 * @param {boolean} darkmode Turn on darkmode, this results into a different cache file
+	 */
+	async run(wallpaperArray, darkmode) {
+		// Cancel already running processes before starting new ones
+		this.cancelRunning();
+
+		// Needs a copy here
+		let hydraPaperCommand = [...this.#hydraPaperCommand];
+
+		if (darkmode) {
+			hydraPaperCommand.push('--darkmode');
+		}
+
+		hydraPaperCommand.push('--cli');
+		hydraPaperCommand = hydraPaperCommand.concat(wallpaperArray);
+
+		try {
+			this.#hydraPaperCancellable = new Gio.Cancellable();
+
+			// hydrapaper [--darkmode] --cli PATH PATH PATH
+			await Utils.Utils.execCheck(hydraPaperCommand, this.#hydraPaperCancellable);
+
+			this.#hydraPaperCancellable = null;
+		} catch (error) {
+			logError(error);
+		}
+	}
+}

--- a/randomwallpaper@iflow.space/jsonpath/jsonpath.js
+++ b/randomwallpaper@iflow.space/jsonpath/jsonpath.js
@@ -1,7 +1,7 @@
 const Self = imports.misc.extensionUtils.getCurrentExtension();
 const Utils = Self.imports.utils;
 
-var JSONPathParser = function () {
+var JSONPathParser = class {
 
 	/**
 	 * Access a simple json path expression of an object.
@@ -13,7 +13,7 @@ var JSONPathParser = function () {
 	 * @param newRandomness whether to ignore previously defined random Elements
 	 * @returns {*}
 	 */
-	this.access = function (inputObject, inputString, randomElements = null, newRandomness = true) {
+	static access(inputObject, inputString, randomElements = null, newRandomness = true) {
 		if (inputObject === null || inputObject === undefined) {
 			return null;
 		}
@@ -90,7 +90,7 @@ var JSONPathParser = function () {
 	 * @returns {*}
 	 * @private
 	 */
-	this._getTargetObject = function (inputObject, keyString) {
+	static _getTargetObject(inputObject, keyString) {
 		if (!keyString.empty && keyString !== "$" && !inputObject.hasOwnProperty(keyString)) {
 			return null;
 		}
@@ -104,7 +104,7 @@ var JSONPathParser = function () {
 	 * @param inputObject
 	 * @returns {*}
 	 */
-	this.randomElement = function (inputObject) {
+	static randomElement(inputObject) {
 		let keys = Object.keys(inputObject);
 		let randomIndex = Utils.Utils.getRandomNumber(keys.length);
 

--- a/randomwallpaper@iflow.space/prefs.js
+++ b/randomwallpaper@iflow.space/prefs.js
@@ -106,7 +106,7 @@ var RandomWallpaperSettings = class {
 			sourceRow.button_delete.connect('clicked', () => {
 				sourceRow.clearConfig();
 				this._builder.get_object('sources_list').remove(sourceRow);
-				this._removeItemOnce(this._sources, id);
+				Utils.Utils.removeItemOnce(this._sources, id);
 				this._saveSources();
 			});
 		});
@@ -122,13 +122,6 @@ var RandomWallpaperSettings = class {
 		}
 	}
 
-	// https://stackoverflow.com/a/5767357
-	_removeItemOnce(arr, value) {
-		var index = arr.indexOf(value);
-		if (index > -1) {
-			arr.splice(index, 1);
-		}
-		return arr;
 	}
 
 	_bindButtons() {
@@ -160,7 +153,7 @@ var RandomWallpaperSettings = class {
 			sourceRow.button_delete.connect('clicked', () => {
 				sourceRow.clearConfig();
 				sourceRowList.remove(sourceRow);
-				this._removeItemOnce(this._sources, sourceRow.id);
+				Utils.Utils.removeItemOnce(this._sources, sourceRow.id);
 				this._saveSources();
 			});
 		});

--- a/randomwallpaper@iflow.space/prefs.js
+++ b/randomwallpaper@iflow.space/prefs.js
@@ -7,6 +7,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Self = ExtensionUtils.getCurrentExtension();
 const SourceRow = Self.imports.ui.sourceRow;
 const Settings = Self.imports.settings;
+const Utils = Self.imports.utils;
 const WallpaperController = Self.imports.wallpaperController;
 
 const LoggerModule = Self.imports.logger;
@@ -83,6 +84,10 @@ var RandomWallpaperSettings = class {
 			this._builder.get_object('general_post_command'),
 			'text',
 			Gio.SettingsBindFlags.DEFAULT);
+		this._settings.bind('multiple-displays',
+			this._builder.get_object('enable_multiple_displays'),
+			'active',
+			Gio.SettingsBindFlags.DEFAULT);
 
 		this._bindButtons();
 		this._bindHistorySection(window);
@@ -105,6 +110,16 @@ var RandomWallpaperSettings = class {
 				this._saveSources();
 			});
 		});
+
+		try {
+			Utils.Utils.getHydraPaperAvailable().then(result => {
+				if (result === true) {
+					this._builder.get_object('multiple_displays_row').set_sensitive(true);
+				}
+			});
+		} catch (error) {
+			// Should already be handled at wallpaperController although in a different context
+		}
 	}
 
 	// https://stackoverflow.com/a/5767357

--- a/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
+++ b/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
@@ -85,6 +85,12 @@
             <description>Run a command after setting a wallpaper.</description>
         </key>
 
+        <key type='b' name='multiple-displays'>
+            <default>false</default>
+            <summary>Different wallpaper for multiple displays</summary>
+            <description>Display different wallpaper on different displays.</description>
+        </key>
+
     </schema>
 
     <schema path="/org/gnome/shell/extensions/space-iflow-randomwallpaper/backend-connection/"

--- a/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
+++ b/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain='gnome-shell-extensions'>
 
+    <enum id='org.gnome.shell.extensions.space.iflow.randomwallpaper.change-types'>
+        <value value='0' nick='Background' />
+        <value value='1' nick='Lock Screen' />
+        <value value='2' nick='Background and Lock Screen' />
+        <!-- <value value='3' nick='Background and Lock Screen independently' /> -->
+    </enum>
+
     <schema path="/org/gnome/shell/extensions/space-iflow-randomwallpaper/"
         id='org.gnome.shell.extensions.space.iflow.randomwallpaper'>
 
@@ -49,10 +56,10 @@
             <description>A JS timestamp of the last timer callback trigger. Zero if no last change registered.</description>
         </key>
 
-        <key type='b' name='change-lock-screen'>
-            <default>false</default>
-            <summary>Change lock screen</summary>
-            <description>Weather the gnome lock screen should also be set to the new wallpaper.</description>
+        <key name='change-type' enum='org.gnome.shell.extensions.space.iflow.randomwallpaper.change-types'>
+            <default>"Background"</default>
+            <summary>Choose what should be changed</summary>
+            <description>Allows to choose what backgrounds will be changed.</description>
         </key>
 
         <key type='b' name='disable-hover-preview'>

--- a/randomwallpaper@iflow.space/ui/pageGeneral.blp
+++ b/randomwallpaper@iflow.space/ui/pageGeneral.blp
@@ -56,6 +56,16 @@ Adw.PreferencesPage page_general {
     Adw.EntryRow general_post_command {
       title: _("Run post-command - available variables: %wallpaper_path%");
     }
+
+    Adw.ActionRow multiple_displays_row {
+      title: _("Different wallpapers on multiple displays");
+      subtitle: _("Requires HydraPaper.\nFills from History.");
+      sensitive: false;
+
+      Switch enable_multiple_displays {
+        valign: center;
+      }
+    }
   }
 
   Adw.PreferencesGroup {

--- a/randomwallpaper@iflow.space/ui/pageGeneral.blp
+++ b/randomwallpaper@iflow.space/ui/pageGeneral.blp
@@ -26,13 +26,9 @@ Adw.PreferencesPage page_general {
   Adw.PreferencesGroup {
     title: _("General Settings");
 
-    Adw.ActionRow {
-      title: _("Change lock screen");
-      subtitle: _("Change the gnome lock screen image to the new wallpaper.");
-
-      Switch change_lock_screen {
-        valign: center;
-      }
+    Adw.ComboRow combo_background_type {
+      title: _("Change type");
+      use-subtitle: true;
     }
 
     Adw.ActionRow {

--- a/randomwallpaper@iflow.space/ui/sourceRow.js
+++ b/randomwallpaper@iflow.space/ui/sourceRow.js
@@ -7,6 +7,7 @@ const Gtk = imports.gi.Gtk;
 
 const Self = ExtensionUtils.getCurrentExtension();
 const Settings = Self.imports.settings;
+const Utils = Self.imports.utils;
 
 const GenericJson = Self.imports.ui.genericJson;
 const LocalFolder = Self.imports.ui.localFolder;
@@ -146,17 +147,8 @@ var SourceRow = GObject.registerClass({
 			return;
 		}
 
-		blockedImages = this._removeItemOnce(blockedImages, filename);
+		blockedImages = Utils.Utils.removeItemOnce(blockedImages, filename);
 		this._settings.set('blocked-images', 'strv', blockedImages);
-	}
-
-	// https://stackoverflow.com/a/5767357
-	_removeItemOnce(arr, value) {
-		var index = arr.indexOf(value);
-		if (index > -1) {
-			arr.splice(index, 1);
-		}
-		return arr;
 	}
 
 	clearConfig() {

--- a/randomwallpaper@iflow.space/utils.js
+++ b/randomwallpaper@iflow.space/utils.js
@@ -3,6 +3,70 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 
 var Utils = class {
+	static #hydraPaperCommand = null;
+
+	/**
+	 * Check whether HydraPaper is available on this system.
+	 * @returns {boolean} - Whether HydraPaper is available
+	 */
+	static async getHydraPaperAvailable() {
+		if (this.#hydraPaperCommand !== null) {
+			return true;
+		}
+
+		try {
+			// Normal installation:
+			await this.#execCheck(['hydrapaper', '--help']);
+
+			this.#hydraPaperCommand = ['hydrapaper'];
+			return true;
+		} catch (error) {
+			// logError(error);
+		}
+
+		try {
+			// FlatPak installation:
+			await this.#execCheck(['org.gabmus.hydrapaper', '--help']);
+
+			this.#hydraPaperCommand = ['org.gabmus.hydrapaper'];
+			return true;
+		} catch (error) {
+			// logError(error);
+		}
+
+		return this.#hydraPaperCommand !== null;
+	}
+
+	/**
+	 * Get the command found for HydraPaper.
+	 * Call getHydraPaperAvailable once to have this variable filled.
+	 *
+	 * @returns {Array<string>?} argv for HydraPaper
+	 */
+	static getHydraPaperCommand() {
+		return this.#hydraPaperCommand;
+	}
+
+	/**
+	 * Get the monitor count for the default "seat".
+	 * @returns Number
+	 */
+	static getMonitorCount() {
+		// Gdk 4.8+
+		// Gdk.DisplayManager.get()
+		// displayManager.get_default_display()
+		// display.get_monitors()
+		// monitors.get_n_items() <- Monitor count, number
+
+		// let defaultDisplay = Gdk.Display.get_default(); // default "seat" which can have multiple monitors
+		// let monitorList = defaultDisplay.get_monitors(); // Gio.ListModel containing all "Gdk.Monitor"
+		// return monitorList.get_n_items();
+
+		// Gdk < 4.8
+		let defaultDisplay = Gdk.Display.get_default(); // default "seat" which can have multiple monitors
+		return defaultDisplay.get_n_monitors();
+	}
+
 	static getRandomNumber(size) {
 		return Math.floor(Math.random() * size);
 	}

--- a/randomwallpaper@iflow.space/utils.js
+++ b/randomwallpaper@iflow.space/utils.js
@@ -116,4 +116,13 @@ var Utils = class {
 			});
 		});
 	}
+
+	// https://stackoverflow.com/a/5767357
+	static removeItemOnce(arr, value) {
+		var index = arr.indexOf(value);
+		if (index > -1) {
+			arr.splice(index, 1);
+		}
+		return arr;
+	}
 }

--- a/randomwallpaper@iflow.space/utils.js
+++ b/randomwallpaper@iflow.space/utils.js
@@ -16,7 +16,7 @@ var Utils = class {
 
 		try {
 			// Normal installation:
-			await this.#execCheck(['hydrapaper', '--help']);
+			await this.execCheck(['hydrapaper', '--help']);
 
 			this.#hydraPaperCommand = ['hydrapaper'];
 			return true;
@@ -26,7 +26,7 @@ var Utils = class {
 
 		try {
 			// FlatPak installation:
-			await this.#execCheck(['org.gabmus.hydrapaper', '--help']);
+			await this.execCheck(['org.gabmus.hydrapaper', '--help']);
 
 			this.#hydraPaperCommand = ['org.gabmus.hydrapaper'];
 			return true;
@@ -71,25 +71,6 @@ var Utils = class {
 		return Math.floor(Math.random() * size);
 	}
 
-	// https://gjs.guide/guides/gio/subprocesses.html#waiting-for-processes
-	static runCommand(argv) {
-		return new Promise((resolve, reject) => {
-			try {
-				let proc = Gio.Subprocess.new(argv, Gio.SubprocessFlags.NONE);
-
-				proc.wait_async(null, (proc, result) => {
-					try {
-						resolve(proc.wait_finish(result));
-					} catch (error) {
-						reject(error);
-					}
-				});
-			} catch (error) {
-				reject(error);
-			}
-		});
-	}
-
 	// https://gjs.guide/guides/gio/subprocesses.html#complete-examples
 	/**
 	 * Execute a command asynchronously and check the exit status.
@@ -100,7 +81,7 @@ var Utils = class {
 	 * @param {Gio.Cancellable} [cancellable] - optional cancellable object
 	 * @returns {Promise<>} - The process success
 	 */
-	static async #execCheck(argv, cancellable = null) {
+	static async execCheck(argv, cancellable = null) {
 		let cancelId = 0;
 		let proc = new Gio.Subprocess({
 			argv: argv,

--- a/randomwallpaper@iflow.space/utils.js
+++ b/randomwallpaper@iflow.space/utils.js
@@ -3,50 +3,6 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 
 var Utils = class {
-	static #hydraPaperCommand = null;
-
-	/**
-	 * Check whether HydraPaper is available on this system.
-	 * @returns {boolean} - Whether HydraPaper is available
-	 */
-	static async getHydraPaperAvailable() {
-		if (this.#hydraPaperCommand !== null) {
-			return true;
-		}
-
-		try {
-			// Normal installation:
-			await this.execCheck(['hydrapaper', '--help']);
-
-			this.#hydraPaperCommand = ['hydrapaper'];
-			return true;
-		} catch (error) {
-			// logError(error);
-		}
-
-		try {
-			// FlatPak installation:
-			await this.execCheck(['org.gabmus.hydrapaper', '--help']);
-
-			this.#hydraPaperCommand = ['org.gabmus.hydrapaper'];
-			return true;
-		} catch (error) {
-			// logError(error);
-		}
-
-		return this.#hydraPaperCommand !== null;
-	}
-
-	/**
-	 * Get the command found for HydraPaper.
-	 * Call getHydraPaperAvailable once to have this variable filled.
-	 *
-	 * @returns {Array<string>?} argv for HydraPaper
-	 */
-	static getHydraPaperCommand() {
-		return this.#hydraPaperCommand;
-	}
-
 	/**
 	 * Get the monitor count for the default "seat".
 	 * @returns Number

--- a/randomwallpaper@iflow.space/wallpaperController.js
+++ b/randomwallpaper@iflow.space/wallpaperController.js
@@ -257,7 +257,7 @@ var WallpaperController = class {
 		let wallpaperUri = "file://" + path;
 
 		try {
-			if (this._settings.get('multiple-displays', 'boolean') && monitorCount > 1 && await Utils.Utils.getHydraPaperAvailable()) {
+			if (this._settings.get('multiple-displays', 'boolean') && await Utils.Utils.getHydraPaperAvailable()) {
 				// Needs a copy here
 				let hydraPaperCommand = [...Utils.Utils.getHydraPaperCommand()];
 

--- a/randomwallpaper@iflow.space/wallpaperController.js
+++ b/randomwallpaper@iflow.space/wallpaperController.js
@@ -274,8 +274,12 @@ var WallpaperController = class {
 				}
 
 				try {
+					this._hydraPaperCancellable = new Gio.Cancellable();
+
 					// hydrapaper [--darkmode] --cli PATH PATH PATH
-					await Utils.Utils.runCommand(hydraPaperCommand);
+					await Utils.Utils.execCheck(hydraPaperCommand, this._hydraPaperCancellable);
+
+					this._hydraPaperCancellable = null;
 				} catch (error) {
 					this.logger.warn(error);
 				}
@@ -303,7 +307,7 @@ var WallpaperController = class {
 		let generalPostCommandArray = this._getCommandArray(commandString, path);
 		if (generalPostCommandArray !== null) {
 			try {
-				await Utils.Utils.runCommand(generalPostCommandArray);
+				await Utils.Utils.execCheck(generalPostCommandArray);
 			} catch (error) {
 				this.logger.warn(error);
 			}
@@ -472,6 +476,11 @@ var WallpaperController = class {
 		delay = delay || 200;
 
 		this.timeout = Mainloop.timeout_add(Mainloop.PRIORITY_DEFAULT, delay, () => {
+			if (this._hydraPaperCancellable instanceof Gio.Cancellable) {
+				this._hydraPaperCancellable.cancel();
+				this._hydraPaperCancellable = null;
+			}
+
 			this.timeout = null;
 			if (this._resetWallpaper) {
 				this._setBackground(this._historyController.getCurrentElement().path);

--- a/randomwallpaper@iflow.space/wallpaperController.js
+++ b/randomwallpaper@iflow.space/wallpaperController.js
@@ -75,7 +75,7 @@ var WallpaperController = class {
 			this.fetchNewWallpaper();
 		}
 
-		this.currentWallpaper = this._getCurrentWallpaper();
+		this._currentWallpaper = this._getCurrentWallpaper();
 
 		// Initialize favorites folder
 		// TODO: There's probably a better place for this
@@ -371,7 +371,7 @@ var WallpaperController = class {
 
 		if (this._historyController.promoteToActive(historyElement.id)) {
 			this._setBackground(historyElement.path).then(() => {
-				this.currentWallpaper = this._getCurrentWallpaper();
+				this._currentWallpaper = this._getCurrentWallpaper();
 			});
 		} else {
 			this.logger.warn("The history id (" + historyElement.id + ") could not be found.")
@@ -432,7 +432,7 @@ var WallpaperController = class {
 				this._setBackground(historyElement.path, () => {
 					// insert file into history
 					this._historyController.insert(historyElement);
-					this.currentWallpaper = this._getCurrentWallpaper();
+					this._currentWallpaper = this._getCurrentWallpaper();
 
 					this._stopLoadingHooks.forEach(element => element(null));
 
@@ -484,7 +484,7 @@ var WallpaperController = class {
 		this.timeout = Mainloop.timeout_add(Mainloop.PRIORITY_DEFAULT, delay, () => {
 			this.timeout = null;
 			if (this._resetWallpaper) {
-				this._setBackground(this.currentWallpaper);
+				this._setBackground(this._currentWallpaper);
 				this._resetWallpaper = false;
 			} else {
 				this._setBackground(this.wallpaperLocation + this.previewId);
@@ -519,7 +519,7 @@ var WallpaperController = class {
 
 	update() {
 		this._updateHistory();
-		this.currentWallpaper = this._getCurrentWallpaper();
+		this._currentWallpaper = this._getCurrentWallpaper();
 	}
 
 	registerStartLoadingHook(fn) {


### PR DESCRIPTION
If available and activated [HydraPaper](https://gitlab.gnome.org/GabMus/HydraPaper) can now be used to populate multiple displays.
This also works together with `hydrapaperd`, the daemon which tracks monitor changes: `systemctl enable --now --user org.gabmus.hyperpaperd.service`
Fixes #117 

---

Only the lock screen can be changed now.
Fix #74 and partially #70