### PR TITLE
Add ratio filter

### DIFF
--- a/randomwallpaper@iflow.space/prefs.js
+++ b/randomwallpaper@iflow.space/prefs.js
@@ -206,11 +206,19 @@ var RandomWallpaperSettings = class {
 			this._builder.get_object('wallhaven-api-key'),
 			'text',
 			Gio.SettingsBindFlags.DEFAULT);
-		this._wallhaven_settings.bind('resolutions',
-			this._builder.get_object('wallhaven-resolutions'),
+		this._wallhaven_settings.bind('ratios',
+			this._builder.get_object('wallhaven-ratios'),
 			'text',
 			Gio.SettingsBindFlags.DEFAULT);
-
+		this._wallhaven_settings.bind('wallhaven-minimal-width',
+			this._builder.get_object('wallhaven-minimal-width'),
+			'value',
+			Gio.SettingsBindFlags.DEFAULT);
+		this._wallhaven_settings.bind('wallhaven-minimal-height',
+			this._builder.get_object('wallhaven-minimal-height'),
+			'value',
+			Gio.SettingsBindFlags.DEFAULT);
+		
 		this._wallhaven_settings.bind('category-general',
 			this._builder.get_object('wallhaven-category-general'),
 			'active',

--- a/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
+++ b/randomwallpaper@iflow.space/schemas/org.gnome.shell.extensions.space.iflow.randomwallpaper.gschema.xml
@@ -151,10 +151,20 @@
             <summary>Api key</summary>
             <description>The wallheven api key.</description>
         </key>
-        <key type='s' name='resolutions'>
-            <default>"1920x1200, 1920x1080, 2560x1440, 2560x1600, 3840x1080"</default>
-            <summary>Resolutions</summary>
-            <description>The acceptable resolutions.</description>
+        <key type='s' name='ratios'>
+            <default>"16x9, 16x10"</default>
+            <summary>Ratios</summary>
+            <description>The acceptable ratios.</description>
+        </key>
+        <key type='i' name='wallhaven-minimal-width'>
+            <default>0</default>
+            <summary>Minimal Width</summary>
+            <description>The minimal width for image.</description>
+        </key>
+        <key type='i' name='wallhaven-minimal-height'>
+            <default>0</default>
+            <summary>Minimal Height</summary>
+            <description>The minimal height for image.</description>
         </key>
         <key type='b' name='allow-sfw'>
             <default>true</default>

--- a/randomwallpaper@iflow.space/settings.ui
+++ b/randomwallpaper@iflow.space/settings.ui
@@ -1146,19 +1146,84 @@ You can also define a prefix that will be added to the image URL.</property>
         </child>
       </object>
     </child>
+
     <child>
       <object class="GtkLabel">
         <property name="visible">1</property>
         <property name="margin-top">10</property>
         <property name="halign">start</property>
-        <property name="label" translatable="yes">Resolutions</property>
+        <property name="label" translatable="yes">Ratios</property>
       </object>
     </child>
     <child>
-      <object class="GtkEntry" id="wallhaven-resolutions">
+      <object class="GtkEntry" id="wallhaven-ratios">
         <property name="visible">1</property>
         <property name="can-focus">1</property>
-        <property name="placeholder-text" translatable="yes">1920x1080, 1920x1200</property>
+        <property name="placeholder-text" translatable="yes">16x9, 16x10 (leave blank for all)</property>
+      </object>
+    </child>
+
+    <child>
+    <object class="GtkAdjustment" id="wallhaven-minimal-height">
+        <property name="lower">0</property>
+        <property name="upper">1000000</property>
+        <property name="step-increment">10</property>
+        <property name="page-increment">10</property>
+    </object>
+    <object class="GtkAdjustment" id="wallhaven-minimal-width">
+        <property name="lower">0</property>
+        <property name="upper">1000000</property>
+        <property name="step-increment">10</property>
+        <property name="page-increment">10</property>
+    </object>
+
+      <object class="GtkBox">
+        <property name="visible">1</property>
+        <property name="spacing">10</property>
+        <property name="margin-bottom">10</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="hexpand">1</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Minimal Width</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSpinButton">
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="adjustment">wallhaven-minimal-width</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">1</property>
+            <property name="hexpand">1</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Minimal Height</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkSpinButton">
+                <property name="visible">1</property>
+                <property name="can-focus">1</property>
+                <property name="adjustment">wallhaven-minimal-height</property>
+              </object>
+            </child>
+          </object>
+        </child>
+
       </object>
     </child>
   </object>

--- a/randomwallpaper@iflow.space/sourceAdapter.js
+++ b/randomwallpaper@iflow.space/sourceAdapter.js
@@ -186,7 +186,8 @@ var WallhavenAdapter = class extends BaseAdapter {
 			'purity': '110', // SFW, sketchy
 			'sorting': 'random',
 			'categories': '111', // General, Anime, People
-			'resolutions': ['1920x1200', '2560x1440']
+			'ratios': ['16x9', '16x10'],
+			'atleast': '0x0' // Minimal size for image
 		};
 
 		this._settings = new SettingsModule.Settings(RWG_SETTINGS_SCHEMA_WALLHAVEN);
@@ -260,10 +261,14 @@ var WallhavenAdapter = class extends BaseAdapter {
 		}
 		this.options.apikey = this._settings.get('wallhaven-api-key', 'string');
 
-		this.options.resolutions = this._settings.get('resolutions', 'string').split(',');
-		this.options.resolutions = this.options.resolutions.map((elem) => {
+		this.options.ratios = this._settings.get('ratios', 'string').split(',');
+		this.options.ratios = this.options.ratios.map((elem) => {
 			return elem.trim();
 		});
+
+		let minimal_width = this._settings.get('wallhaven-minimal-width', 'int');
+		let minimal_height = this._settings.get('wallhaven-minimal-height', 'int');
+		this.options.atleast = minimal_width + "x" + minimal_height;
 
 		let categories = [];
 		categories.push(+this._settings.get('category-general', 'boolean')); // + is implicit conversion to int


### PR DESCRIPTION
Hi there, so basically this PR replaces filtering with resolutions on ratios and minimum width/height filtering for Wallhaven. The goal is to improve the quality of image request, because with strict filtering by resolutions, it's often happens that Wallhaven has an image that fits the keywords, but does not have an image that matches the exact resolutions specified by users, which limits the variety of wallpapers. Now it is possible to filter images using proportions, and to specify the resolution (quality) of the image by giving the minimum height and width of the image, making it easier for users to specify images without incorrect limiting.
![image](https://user-images.githubusercontent.com/60938676/215250399-9914b4c5-2bc2-48a2-a234-98f3a4eb9531.png)
