### PR TITLE
Support Gnome45

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,8 +52,6 @@ compile_js() {
     npx tsc
 }
 
-# TODO: Drop compiled schemas when only targeting Gnome 44+
-# https://gjs.guide/extensions/upgrading/gnome-shell-44.html#gsettings-schema
 compile_schemas() {
     check_command "glib-compile-schemas"
     mkdir -p "$DESTDIR/schemas/"
@@ -122,6 +120,9 @@ if [ $# -eq 0 ]; then
 elif [ "$1" == "check" ]; then
     check_ts
 elif [ "$1" == "build" ]; then
+    compile_ui
+    compile_js
+elif [ "$1" == "build_local" ]; then
     compile_ui
     compile_js
     compile_schemas

--- a/build.sh
+++ b/build.sh
@@ -50,13 +50,6 @@ compile_js() {
 
     # TypeScript to JavaScript, config in tsconfig.json
     npx tsc
-
-    # extension.js and prefs.js can't be modules (yet) while dynamically loaded by GJS…
-    # https://gjs.guide/extensions/overview/imports-and-modules.html#imports-and-modules
-    # …and TypeScript can't compile specific files to "not a module" in overall module mode.
-    # https://github.com/microsoft/TypeScript/issues/41567
-    sed -i -E "s#export \{\};##g" "$DESTDIR/extension.js"
-    sed -i -E "s#export \{\};##g" "$DESTDIR/prefs.js"
 }
 
 # TODO: Drop compiled schemas when only targeting Gnome 44+

--- a/src/adapter/unsplash.ts
+++ b/src/adapter/unsplash.ts
@@ -142,13 +142,13 @@ class UnsplashAdapter extends BaseAdapter {
         let optionsString = '';
 
         switch (options.constraintType) {
-        case 1:
+        case ConstraintType.USER:
             optionsString = `/user/${options.constraintValue}/`;
             break;
-        case 2:
+        case ConstraintType.USERS_LIKES:
             optionsString = `/user/${options.constraintValue}/likes/`;
             break;
-        case 3:
+        case ConstraintType.COLLECTION_ID:
             optionsString = `/collection/${options.constraintValue}/`;
             break;
         default:
@@ -190,54 +190,7 @@ class UnsplashAdapter extends BaseAdapter {
     }
 }
 
-/**
- * Retrieve the human readable enum name.
- *
- * @param {ConstraintType} type The type to name
- * @returns {string} Name
- */
-function _getConstraintTypeName(type: ConstraintType): string {
-    let name: string;
-
-    switch (type) {
-    case ConstraintType.UNCONSTRAINED:
-        name = 'Unconstrained';
-        break;
-    case ConstraintType.USER:
-        name = 'User';
-        break;
-    case ConstraintType.USERS_LIKES:
-        name = 'User\'s Likes';
-        break;
-    case ConstraintType.COLLECTION_ID:
-        name = 'Collection ID';
-        break;
-
-    default:
-        name = 'Constraint type name not found';
-        break;
-    }
-
-    return name;
-}
-
-/**
- * Get a list of human readable enum entries.
- *
- * @returns {string[]} Array with key names
- */
-function getConstraintTypeNameList(): string[] {
-    const list: string[] = [];
-
-    const values = Object.values(ConstraintType).filter(v => !isNaN(Number(v)));
-    for (const i of values)
-        list.push(_getConstraintTypeName(i as ConstraintType));
-
-    return list;
-}
-
 export {
     UnsplashAdapter,
-    ConstraintType,
-    getConstraintTypeNameList
+    ConstraintType
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,10 @@ class RandomWallpaperExtension extends Extension {
      * widgets, connect signals or modify GNOME Shell's behavior.
      */
     enable(): void {
+        // Set statics for the current extension context (shell background)
         Settings.extensionContext = Extension;
+        Logger.SETTINGS = new Settings();
+
         this._timer = AFTimer.AFTimer.getTimer();
         this._wallpaperController = new WallpaperController.WallpaperController();
         this._panelMenu = new RandomWallpaperMenu.RandomWallpaperMenu(this._wallpaperController);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,8 @@
-import type * as LoggerNamespace from './logger.js';
-import type * as AFTimer from './timer.js';
-import type * as WallpaperControllerNamespace from './wallpaperController.js';
-import type * as RandomWallpaperMenuNamespace from './randomWallpaperMenu.js';
-import type {ExtensionMeta} from 'ExtensionMeta';
+import * as AFTimer from './timer.js';
+import * as WallpaperController from './wallpaperController.js';
+import * as RandomWallpaperMenu from './randomWallpaperMenu.js';
 
-let Logger: typeof LoggerNamespace.Logger | null = null;
-let Timer: typeof AFTimer | null = null;
-let WallpaperController: typeof WallpaperControllerNamespace | null = null;
-let RandomWallpaperMenu: typeof RandomWallpaperMenuNamespace | null = null;
+import {Logger} from './logger.js';
 
 /**
  * This function is called once when your extension is loaded, not enabled. This
@@ -30,8 +25,8 @@ function init(unusedMeta: ExtensionMeta): Extension {
  * The functions enable() and disable() are required.
  */
 class Extension {
-    private _wallpaperController: WallpaperControllerNamespace.WallpaperController | null = null;
-    private _panelMenu: RandomWallpaperMenuNamespace.RandomWallpaperMenu | null = null;
+    private _wallpaperController: WallpaperController.WallpaperController | null = null;
+    private _panelMenu: RandomWallpaperMenu.RandomWallpaperMenu | null = null;
     private _timer: AFTimer.AFTimer | null = null;
 
     /**
@@ -42,23 +37,12 @@ class Extension {
      * widgets, connect signals or modify GNOME Shell's behavior.
      */
     enable(): void {
-        // Dynamically load own modules. This allows us to use proper ES6 Modules
-        this._importModules().then(() => {
-            if (!Logger || !Timer || !WallpaperController || !RandomWallpaperMenu)
-                throw new Error('Error importing module');
+        this._timer = AFTimer.AFTimer.getTimer();
+        this._wallpaperController = new WallpaperController.WallpaperController();
+        this._panelMenu = new RandomWallpaperMenu.RandomWallpaperMenu(this._wallpaperController);
 
-            this._timer = Timer.AFTimer.getTimer();
-            this._wallpaperController = new WallpaperController.WallpaperController();
-            this._panelMenu = new RandomWallpaperMenu.RandomWallpaperMenu(this._wallpaperController);
-
-            Logger.info('Enable extension.', this);
-            this._panelMenu.init();
-        }).catch(error => {
-            if (error instanceof Error)
-                logError(error);
-            else
-                logError(new Error('Unknown error'));
-        });
+        Logger.info('Enable extension.', this);
+        this._panelMenu.init();
     }
 
     /**
@@ -69,15 +53,14 @@ class Extension {
      * Not doing so is the most common reason extensions are rejected in review!
      */
     disable(): void {
-        if (Logger)
-            Logger.info('Disable extension.');
+        Logger.info('Disable extension.');
 
         if (this._panelMenu)
             this._panelMenu.cleanup();
 
         // cleanup the timer singleton
-        if (Timer)
-            Timer.AFTimer.destroy();
+        if (this._timer)
+            AFTimer.AFTimer.destroy();
 
         if (this._wallpaperController)
             this._wallpaperController.cleanup();
@@ -86,39 +69,9 @@ class Extension {
         this._panelMenu = null;
         this._wallpaperController = null;
 
-        Timer = null;
-        WallpaperController = null;
-        RandomWallpaperMenu = null;
-
         // Destruction of log helper is the last step
-        if (Logger)
-            Logger.destroy();
-        Logger = null;
-    }
-
-    /**
-     * Import helper function.
-     *
-     * Loads all required modules async.
-     * This allows to omit the legacy GJS style imports (`const asd = imports.gi.asd`)
-     * and use proper modules for subsequent files.
-     *
-     * When the shell allows proper modules for loaded files (extension.js and prefs.js)
-     * this function can be removed and replaced by normal import statements.
-     */
-    private async _importModules(): Promise<void> {
-        const loggerPromise = import('./logger.js');
-        const timerPromise = import('./timer.js');
-        const wallpaperPromise = import('./wallpaperController.js');
-        const menuPromise = import('./randomWallpaperMenu.js');
-
-        const [moduleLogger, moduleTimer, moduleWallpaper, moduleMenu] = await Promise.all([
-            loggerPromise, timerPromise, wallpaperPromise, menuPromise,
-        ]);
-
-        Logger = moduleLogger.Logger;
-        Timer = moduleTimer;
-        WallpaperController = moduleWallpaper;
-        RandomWallpaperMenu = moduleMenu;
+        Logger.destroy();
     }
 }
+
+export {Extension as default};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import * as WallpaperController from './wallpaperController.js';
 import * as RandomWallpaperMenu from './randomWallpaperMenu.js';
 
 import {Logger} from './logger.js';
+import {Settings} from './settings.js';
 
 /**
  * Own extension class object. Entry point for Gnome Shell hooks.
@@ -24,6 +25,7 @@ class RandomWallpaperExtension extends Extension {
      * widgets, connect signals or modify GNOME Shell's behavior.
      */
     enable(): void {
+        Settings.extensionContext = Extension;
         this._timer = AFTimer.AFTimer.getTimer();
         this._wallpaperController = new WallpaperController.WallpaperController();
         this._panelMenu = new RandomWallpaperMenu.RandomWallpaperMenu(this._wallpaperController);
@@ -58,6 +60,7 @@ class RandomWallpaperExtension extends Extension {
 
         // Destruction of log helper is the last step
         Logger.destroy();
+        Settings.extensionContext = undefined;
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,5 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
 import * as AFTimer from './timer.js';
 import * as WallpaperController from './wallpaperController.js';
 import * as RandomWallpaperMenu from './randomWallpaperMenu.js';
@@ -5,26 +7,11 @@ import * as RandomWallpaperMenu from './randomWallpaperMenu.js';
 import {Logger} from './logger.js';
 
 /**
- * This function is called once when your extension is loaded, not enabled. This
- * is a good time to setup translations or anything else you only do once.
- *
- * You MUST NOT make any changes to GNOME Shell, connect any signals or add any
- * MainLoop sources here.
- *
- * @param {ExtensionMeta} unusedMeta An extension meta object, https://gjs.guide/extensions/overview/anatomy.html#extension-meta-object
- * @returns {Extension} an object with enable() and disable() methods
- */
-// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-function init(unusedMeta: ExtensionMeta): Extension {
-    return new Extension();
-}
-
-/**
  * Own extension class object. Entry point for Gnome Shell hooks.
  *
  * The functions enable() and disable() are required.
  */
-class Extension {
+class RandomWallpaperExtension extends Extension {
     private _wallpaperController: WallpaperController.WallpaperController | null = null;
     private _panelMenu: RandomWallpaperMenu.RandomWallpaperMenu | null = null;
     private _timer: AFTimer.AFTimer | null = null;
@@ -74,4 +61,4 @@ class Extension {
     }
 }
 
-export {Extension as default};
+export {RandomWallpaperExtension as default};

--- a/src/historyMenuElements.ts
+++ b/src/historyMenuElements.ts
@@ -6,9 +6,7 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import St from 'gi://St';
 
-// Legacy importing style for shell internal bindings not available in standard import format
-// For correct typing use: 'InstanceType<typeof Adw.ActionRow>'
-const PopupMenu = imports.ui.popupMenu;
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
 import * as HistoryModule from './history.js';
 import * as Settings from './settings.js';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -19,7 +19,7 @@ const LOG_PREFIX = 'RandomWallpaper';
  * A convenience logger class.
  */
 class Logger {
-    private static _SETTINGS: Settings | null = null;
+    public static SETTINGS: Settings | null = null;
 
     /**
      * Helper function to safely log to the console.
@@ -53,14 +53,18 @@ class Logger {
     /**
      * Get the log level selected by the user.
      *
+     * Requires the static SETTINGS member to be set first.
+     * Falls back to LogLevel.WARNING if settings object is not set.
+     *
      * @returns {LogLevel} Log level
      */
     private static _selectedLogLevel(): LogLevel {
-        // lazy initialization of the settings object
-        if (Logger._SETTINGS === null)
-            Logger._SETTINGS = new Settings();
+        if (Logger.SETTINGS === null) {
+            this._log(LogLevel.ERROR, 'Extension context not set before first use!', Logger);
+            return LogLevel.WARNING;
+        }
 
-        return Logger._SETTINGS.getInt('log-level');
+        return Logger.SETTINGS.getInt('log-level');
     }
 
     /**
@@ -123,7 +127,7 @@ class Logger {
      */
     static destroy(): void {
         // clear reference to settings object
-        Logger._SETTINGS = null;
+        Logger.SETTINGS = null;
     }
 }
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": [ "43", "44" ],
+  "shell-version": [ "45" ],
   "uuid": "randomwallpaper@iflow.space",
   "settings-schema": "org.gnome.shell.extensions.space.iflow.randomwallpaper",
   "name": "Random Wallpaper",

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,4 +1,4 @@
-const Main = imports.ui.main;
+import {notify} from 'resource:///org/gnome/shell/ui/main.js';
 
 import {HistoryEntry} from './history.js';
 
@@ -14,9 +14,8 @@ class Notification {
     static newWallpaper(historyEntries: HistoryEntry[]): void {
         const infoString = `Source: ${historyEntries.map(h => `${h.source.source ?? 'Unknown Source'}`).join(', ')}`;
         const message = `A new wallpaper was set!\n${infoString}`;
-        Main.notify('New Wallpaper', message);
+        notify('New Wallpaper', message);
     }
 }
 
 export {Notification};
-

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -11,40 +11,30 @@ import * as WallpaperManager from './manager/wallpaperManager.js';
 
 import {Logger} from './logger.js';
 
-/**
- * Like `extension.js` this is used for any one-time setup like translations.
- *
- * @param {ExtensionMeta} unusedMeta - An extension meta object, https://gjs.guide/extensions/overview/anatomy.html#extension-meta-object
- */
-// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-function init(unusedMeta: ExtensionMeta): void {
-    // Convenience.initTranslations();
-}
-
 // https://gjs.guide/extensions/overview/anatomy.html#prefs-js
 // The code in prefs.js will be executed in a separate Gtk process
 // Here you will not have access to code running in GNOME Shell, but fatal errors or mistakes will be contained within that process.
 // In this process you will be using the Gtk toolkit, not Clutter.
 
-// https://gjs.guide/extensions/development/preferences.html#preferences-window
-// Gnome 42+
 /**
- * This function is called when the preferences window is first created to fill
- * the `Adw.PreferencesWindow`.
- *
- * This function will only be called by GNOME 42 and later. If this function is
- * present, `buildPrefsWidget()` will NOT be called.
- *
- * @param {Adw.PreferencesWindow} window - The preferences window
+ * Initial entry point for the extension settings page
  */
-// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-function fillPreferencesWindow(window: Adw.PreferencesWindow): void {
-    window.set_default_size(600, 720);
-    // temporary fill window to prevent error message until modules are loaded
-    const tmpPage = new Adw.PreferencesPage();
-    window.add(tmpPage);
+export default class RWG3Settings extends ExtensionPreferences {
+    /**
+     * This function is called when the preferences window is first created to fill
+     * the `Adw.PreferencesWindow`.
+     *
+     * @param {Adw.PreferencesWindow} window - The preferences window
+     */
+    // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+    fillPreferencesWindow(window: Adw.PreferencesWindow): void {
+        window.set_default_size(600, 720);
+        // temporary fill window to prevent error message until modules are loaded
+        const tmpPage = new Adw.PreferencesPage();
+        window.add(tmpPage);
 
-    new RandomWallpaperSettings(window, tmpPage);
+        new RandomWallpaperSettings(window, tmpPage);
+    }
 }
 
 /**

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -29,10 +29,13 @@ class RandomWallpaperSettings extends ExtensionPreferences {
      * @param {Adw.PreferencesWindow} window - The preferences window
      */
     fillPreferencesWindow(window: Adw.PreferencesWindow): void {
+        // Set statics for the current extension context (preferences window)
         Settings.Settings.extensionContext = ExtensionPreferences;
+        const settings = new Settings.Settings();
+        Logger.SETTINGS = settings;
+
         const backendConnection = new Settings.Settings(Settings.RWG_SETTINGS_SCHEMA_BACKEND_CONNECTION);
         const builder = new Gtk.Builder();
-        const settings = new Settings.Settings();
         const sources = this._loadSources(settings);
 
         window.set_default_size(600, 720);
@@ -106,6 +109,7 @@ class RandomWallpaperSettings extends ExtensionPreferences {
         window.connect('close-request', () => {
             backendConnection.setBoolean('pause-timer', false);
             Settings.Settings.extensionContext = undefined;
+            Logger.destroy();
         });
 
         window.add(builder.get_object('page_general'));

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -29,6 +29,7 @@ class RandomWallpaperSettings extends ExtensionPreferences {
      * @param {Adw.PreferencesWindow} window - The preferences window
      */
     fillPreferencesWindow(window: Adw.PreferencesWindow): void {
+        Settings.Settings.extensionContext = ExtensionPreferences;
         const backendConnection = new Settings.Settings(Settings.RWG_SETTINGS_SCHEMA_BACKEND_CONNECTION);
         const builder = new Gtk.Builder();
         const settings = new Settings.Settings();
@@ -104,6 +105,7 @@ class RandomWallpaperSettings extends ExtensionPreferences {
 
         window.connect('close-request', () => {
             backendConnection.setBoolean('pause-timer', false);
+            Settings.Settings.extensionContext = undefined;
         });
 
         window.add(builder.get_object('page_general'));

--- a/src/ui/genericJson.ts
+++ b/src/ui/genericJson.ts
@@ -3,16 +3,11 @@ import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 
-// Legacy importing style for shell internal bindings not available in standard import format
-const ExtensionUtils = imports.misc.extensionUtils;
-
 import * as Settings from './../settings.js';
-
-const Self = ExtensionUtils.getCurrentExtension();
 
 const GenericJsonSettingsGroup = GObject.registerClass({
     GTypeName: 'GenericJsonSettingsGroup',
-    Template: GLib.filename_to_uri(`${Self.path}/ui/genericJson.ui`, null),
+    Template: GLib.uri_resolve_relative(import.meta.url, './genericJson.ui', GLib.UriFlags.NONE),
     InternalChildren: [
         'author_name_path',
         'author_url_path',

--- a/src/ui/localFolder.ts
+++ b/src/ui/localFolder.ts
@@ -4,16 +4,11 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 
-// Legacy importing style for shell internal bindings not available in standard import format
-const ExtensionUtils = imports.misc.extensionUtils;
-
 import * as Settings from './../settings.js';
-
-const Self = ExtensionUtils.getCurrentExtension();
 
 const LocalFolderSettingsGroup = GObject.registerClass({
     GTypeName: 'LocalFolderSettingsGroup',
-    Template: GLib.filename_to_uri(`${Self.path}/ui/localFolder.ui`, null),
+    Template: GLib.uri_resolve_relative(import.meta.url, './localFolder.ui', GLib.UriFlags.NONE),
     InternalChildren: [
         'folder',
         'folder_row',

--- a/src/ui/reddit.ts
+++ b/src/ui/reddit.ts
@@ -4,16 +4,11 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 
-// Legacy importing style for shell internal bindings not available in standard import format
-const ExtensionUtils = imports.misc.extensionUtils;
-
 import * as Settings from './../settings.js';
-
-const Self = ExtensionUtils.getCurrentExtension();
 
 const RedditSettingsGroup = GObject.registerClass({
     GTypeName: 'RedditSettingsGroup',
-    Template: GLib.filename_to_uri(`${Self.path}/ui/reddit.ui`, null),
+    Template: GLib.uri_resolve_relative(import.meta.url, './reddit.ui', GLib.UriFlags.NONE),
     InternalChildren: [
         'allow_sfw',
         'image_ratio1',

--- a/src/ui/sourceRow.ts
+++ b/src/ui/sourceRow.ts
@@ -4,9 +4,6 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 
-// Legacy importing style for shell internal bindings not available in standard import format
-const ExtensionUtils = imports.misc.extensionUtils;
-
 import * as Settings from './../settings.js';
 import * as Utils from './../utils.js';
 
@@ -19,12 +16,10 @@ import {UnsplashSettingsGroup} from './unsplash.js';
 import {UrlSourceSettingsGroup} from './urlSource.js';
 import {WallhavenSettingsGroup} from './wallhaven.js';
 
-const Self = ExtensionUtils.getCurrentExtension();
-
 // https://gitlab.gnome.org/GNOME/gjs/-/blob/master/examples/gtk4-template.js
 const SourceRow = GObject.registerClass({
     GTypeName: 'SourceRow',
-    Template: GLib.filename_to_uri(`${Self.path}/ui/sourceRow.ui`, null),
+    Template: GLib.uri_resolve_relative(import.meta.url, './sourceRow.ui', GLib.UriFlags.NONE),
     Children: [
         'button_delete',
     ],

--- a/src/ui/unsplash.ts
+++ b/src/ui/unsplash.ts
@@ -5,7 +5,16 @@ import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 
 import * as Settings from './../settings.js';
-import {getConstraintTypeNameList} from '../adapter/unsplash.js';
+
+// Generated code produces a no-shadow rule error
+/* eslint-disable */
+enum ConstraintType {
+    UNCONSTRAINED,
+    USER,
+    USERS_LIKES,
+    COLLECTION_ID,
+}
+/* eslint-enable */
 
 const UnsplashSettingsGroup = GObject.registerClass({
     GTypeName: 'UnsplashSettingsGroup',
@@ -107,5 +116,51 @@ const UnsplashSettingsGroup = GObject.registerClass({
         this._settings.resetSchema();
     }
 });
+
+/**
+ * Retrieve the human readable enum name.
+ *
+ * @param {ConstraintType} type The type to name
+ * @returns {string} Name
+ */
+function _getConstraintTypeName(type: ConstraintType): string {
+    let name: string;
+
+    switch (type) {
+    case ConstraintType.UNCONSTRAINED:
+        name = 'Unconstrained';
+        break;
+    case ConstraintType.USER:
+        name = 'User';
+        break;
+    case ConstraintType.USERS_LIKES:
+        name = 'User\'s Likes';
+        break;
+    case ConstraintType.COLLECTION_ID:
+        name = 'Collection ID';
+        break;
+
+    default:
+        name = 'Constraint type name not found';
+        break;
+    }
+
+    return name;
+}
+
+/**
+ * Get a list of human readable enum entries.
+ *
+ * @returns {string[]} Array with key names
+ */
+function getConstraintTypeNameList(): string[] {
+    const list: string[] = [];
+
+    const values = Object.values(ConstraintType).filter(v => !isNaN(Number(v)));
+    for (const i of values)
+        list.push(_getConstraintTypeName(i as ConstraintType));
+
+    return list;
+}
 
 export {UnsplashSettingsGroup};

--- a/src/ui/unsplash.ts
+++ b/src/ui/unsplash.ts
@@ -4,17 +4,12 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 
-// Legacy importing style for shell internal bindings not available in standard import format
-const ExtensionUtils = imports.misc.extensionUtils;
-
 import * as Settings from './../settings.js';
 import {getConstraintTypeNameList} from '../adapter/unsplash.js';
 
-const Self = ExtensionUtils.getCurrentExtension();
-
 const UnsplashSettingsGroup = GObject.registerClass({
     GTypeName: 'UnsplashSettingsGroup',
-    Template: GLib.filename_to_uri(`${Self.path}/ui/unsplash.ui`, null),
+    Template: GLib.uri_resolve_relative(import.meta.url, './unsplash.ui', GLib.UriFlags.NONE),
     InternalChildren: [
         'constraint_type',
         'constraint_value',

--- a/src/ui/urlSource.ts
+++ b/src/ui/urlSource.ts
@@ -4,16 +4,11 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 
-// Legacy importing style for shell internal bindings not available in standard import format
-const ExtensionUtils = imports.misc.extensionUtils;
-
 import * as Settings from './../settings.js';
-
-const Self = ExtensionUtils.getCurrentExtension();
 
 const UrlSourceSettingsGroup = GObject.registerClass({
     GTypeName: 'UrlSourceSettingsGroup',
-    Template: GLib.filename_to_uri(`${Self.path}/ui/urlSource.ui`, null),
+    Template: GLib.uri_resolve_relative(import.meta.url, './urlSource.ui', GLib.UriFlags.NONE),
     InternalChildren: [
         'author_name',
         'author_url',

--- a/src/ui/wallhaven.ts
+++ b/src/ui/wallhaven.ts
@@ -5,16 +5,11 @@ import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
 
-// Legacy importing style for shell internal bindings not available in standard import format
-const ExtensionUtils = imports.misc.extensionUtils;
-
 import * as Settings from './../settings.js';
-
-const Self = ExtensionUtils.getCurrentExtension();
 
 const WallhavenSettingsGroup = GObject.registerClass({
     GTypeName: 'WallhavenSettingsGroup',
-    Template: GLib.filename_to_uri(`${Self.path}/ui/wallhaven.ui`, null),
+    Template: GLib.uri_resolve_relative(import.meta.url, './wallhaven.ui', GLib.UriFlags.NONE),
     InternalChildren: [
         'ai_art',
         'allow_nsfw',

--- a/src/wallpaperController.ts
+++ b/src/wallpaperController.ts
@@ -1,8 +1,7 @@
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 
-// Legacy importing style for shell internal bindings not available in standard import format
-const ExtensionUtils = imports.misc.extensionUtils;
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import * as HistoryModule from './history.js';
 import * as SettingsModule from './settings.js';
@@ -21,8 +20,6 @@ import {RedditAdapter} from './adapter/reddit.js';
 import {UnsplashAdapter} from './adapter/unsplash.js';
 import {UrlSourceAdapter} from './adapter/urlSource.js';
 import {WallhavenAdapter} from './adapter/wallhaven.js';
-
-const Self = ExtensionUtils.getCurrentExtension();
 
 // https://gjs.guide/guides/gjs/asynchronous-programming.html#promisify-helper
 Gio._promisify(Gio.File.prototype, 'move_async', 'move_finish');
@@ -74,7 +71,13 @@ class WallpaperController {
                 xdg_cache_home = '/tmp';
         }
 
-        this.wallpaperLocation = `${xdg_cache_home}/${Self.metadata['uuid']}/wallpapers/`;
+        const extensionObject = Extension.lookupByURL(import.meta.url);
+        if (!extensionObject) {
+            Logger.error('Own extension object not found!', this);
+            throw new Error('Own extension object not found!');
+        }
+
+        this.wallpaperLocation = `${xdg_cache_home}/${extensionObject.metadata['uuid']}/wallpapers/`;
         const mode = 0o0755;
         GLib.mkdir_with_parents(this.wallpaperLocation, mode);
 
@@ -144,7 +147,7 @@ class WallpaperController {
                 favoritesFolder = Gio.File.new_for_path(directoryPictures);
             }
 
-            favoritesFolder = favoritesFolder.get_child(Self.metadata['uuid']);
+            favoritesFolder = favoritesFolder.get_child(extensionObject.metadata['uuid']);
 
             const favoritesFolderPath = favoritesFolder.get_path();
             if (favoritesFolderPath)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,8 +29,8 @@
             "adw1",
             "gtk4/adw", // locally expose 'gi://Adw' and extend with EntryRow
             "mappings", // missing mappings 'from @gi-types' to 'gi://'
-            "ui", // shell gi imports in legacy import style
-            "misc", // shell gi imports in legacy import style
+            "ui", // shell import types
+            "misc", // extension import types
         ],
 
     },

--- a/types/gtk4/adw/index.d.ts
+++ b/types/gtk4/adw/index.d.ts
@@ -98,9 +98,3 @@ declare module 'gi://Adw' {
         vfunc_set_selection_bounds(start_pos: number, end_pos: number): void;
     }
 }
-
-// extend gi imports interface with adw
-// https://github.com/gi-ts/environment#importsgi
-declare interface GjsGiImports {
-    Adw: typeof import('gi://Adw');
-}

--- a/types/misc/index.d.ts
+++ b/types/misc/index.d.ts
@@ -1,138 +1,103 @@
 /* eslint-disable */
 
-declare module 'extensionUtils' {
-    // https://github.com/yilozt/rounded-window-corners/blob/main/%40imports/misc/extensionUtils.d.ts
-    // GPL3
+declare module 'sharedInternals' {
+    // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/extensions/sharedInternals.js
+    import type Gio from 'gi://Gio';
 
-    import Gio from 'gi://Gio';
+    export class ExtensionBase {
+        /**
+         * @param {object} metadata - metadata passed in when loading the extension
+        */
+        constructor(metadata: ExtensionMetadata)
 
-    /**
-     * getCurrentExtension:
-     *
-     * @returns {?object} - The current extension, or null if not called from
-     * an extension.
-     */
-    export function getCurrentExtension(): {
-        uuid: string,
-        path: string,
-        dir: Gio.File,
-        metadata: {
+        /** the metadata.json file, parsed as JSON */
+        readonly metadata: {
             'settings-schema': string,
             uuid: string,
-        }
-    };
-    /**
-     * initTranslations:
-     * @param {string=} domain - the gettext domain to use
-     *
-     * Initialize Gettext to load translations from extensionsdir/locale.
-     * If @domain is not provided, it will be taken from metadata['gettext-domain']
-     */
-    export function initTranslations(domain?: string | undefined): void;
-    /**
-     * gettext:
-     * @param {string} str - the string to translate
-     *
-     * Translate @str using the extension's gettext domain
-     *
-     * @returns {string} - the translated string
-     *
-     */
-    export function gettext(str: string): string;
-    /**
-     * ngettext:
-     * @param {string} str - the string to translate
-     * @param {string} strPlural - the plural form of the string
-     * @param {number} n - the quantity for which translation is needed
-     *
-     * Translate @str and choose plural form using the extension's
-     * gettext domain
-     *
-     * @returns {string} - the translated string
-     *
-     */
-    export function ngettext(str: string, strPlural: string, n: number): string;
-    /**
-     * pgettext:
-     * @param {string} context - context to disambiguate @str
-     * @param {string} str - the string to translate
-     *
-     * Translate @str in the context of @context using the extension's
-     * gettext domain
-     *
-     * @returns {string} - the translated string
-     *
-     */
-    export function pgettext(context: string, str: string): string;
-    export function callExtensionGettextFunc(func: any, ...args: any[]): any;
-    /**
-     * getSettings:
-     * @param {string?} schema - the GSettings schema id
-     * @returns {Gio.Settings} - a new settings object for @schema
-     *
-     * Builds and returns a GSettings schema for @schema, using schema files
-     * in extensionsdir/schemas. If @schema is omitted, it is taken from
-     * metadata['settings-schema'].
-     */
-    export function getSettings(schema?: string | undefined): Gio.Settings;
-    /**
-     * openPrefs:
-     *
-     * Open the preference dialog of the current extension
-     */
-    export function openPrefs(): Promise<void>;
-    export function isOutOfDate(extension: any): boolean;
-    export function serializeExtension(extension: any): {};
-    export function deserializeExtension(variant: any): {
-        metadata: {};
-    };
-    export function installImporter(extension: any): void;
-    export const Gettext: any;
-    export const Config: any;
-    export namespace ExtensionType {
-        const SYSTEM: number;
-        const PER_USER: number;
+            // …
+        };
+
+        /** the extension UUID */
+        readonly uuid: string;
+        /** the extension directory */
+        readonly dir: Gio.File;
+        /** the extension directory path */
+        readonly path: string;
+
+        /**
+         * Get a GSettings object for schema, using schema files in
+         * extensionsdir/schemas. If schema is omitted, it is taken
+         * from metadata['settings-schema'].
+         *
+         * @param {string=} schema - the GSettings schema id
+         *
+         * @returns {Gio.Settings}
+         */
+        getSettings(schema?: string | undefined): Gio.Settings;
+
+        /**
+         * Initialize Gettext to load translations from extensionsdir/locale. If
+         * domain is not provided, it will be taken from metadata['gettext-domain']
+         * if provided, or use the UUID
+         *
+         * @param {string=} domain - the gettext domain to use
+         */
+        initTranslations(domain?: string | undefined): void;
+
+        /**
+         * Translate `str` using the extension's gettext domain
+         *
+         * @param {string} str - the string to translate
+         *
+         * @returns {string} the translated string
+         */
+        gettext(str: string): string;
+
+        /**
+         * Translate `str` and choose plural form using the extension's
+         * gettext domain
+         *
+         * @param {string} str - the string to translate
+         * @param {string} strPlural - the plural form of the string
+         * @param {number} n - the quantity for which translation is needed
+         *
+         * @returns {string} the translated string
+         */
+        ngettext(str: string, strPlural: string, n: number): string;
+
+        /**
+         * Translate `str` in the context of `context` using the extension's
+         * gettext domain
+         *
+         * @param {string} context - context to disambiguate `str`
+         * @param {string} str - the string to translate
+         *
+         * @returns {string} the translated string
+         */
+        pgettext(context: string, str: string): string;
+
+        /** lookup the extension object from any module by using the static method */
+        static lookupByUUID(uuid: string): ExtensionBase | null;
+        /** lookup the extension object from any module by using the static method */
+        static lookupByURL(url: string): ExtensionBase | null;
     }
-    export namespace ExtensionState {
-        const ENABLED: number;
-        const DISABLED: number;
-        const ERROR: number;
-        const OUT_OF_DATE: number;
-        const DOWNLOADING: number;
-        const INITIALIZED: number;
-        const UNINSTALLED: number;
-    }
-    export const SERIALIZED_PROPERTIES: string[];
 }
 
-declare interface GjsMiscImports {
-    extensionUtils: typeof import('extensionUtils');
-}
-
-// extend imports interface with misc elements
-declare interface GjsImports {
-    misc: GjsMiscImports;
-}
-
-declare module 'ExtensionMeta' {
-    import type {File} from 'gi://Gio';
+declare module 'resource:///org/gnome/shell/extensions/extension.js' {
+    import {ExtensionBase} from 'sharedInternals';
 
     /**
      * An object describing the extension and various properties available for extensions to use.
      *
      * Some properties may only be available in some versions of GNOME Shell, while others may not be meant for extension authors to use. All properties should be considered read-only.
      */
-    export class ExtensionMeta {
-        /** the metadata.json file, parsed as JSON */
-        readonly metadata: unknown;
-        /** the extension UUID */
-        readonly uuid: string;
+    export class Extension extends ExtensionBase {
+        constructor(metadata: ExtensionMetadata) {
+            super(metadata);
+        }
+
         /** the extension type; `1` for system, `2` for user */
         readonly type: number;
-        /** the extension directory */
-        readonly dir: File;
-        /** the extension directory path */
-        readonly path: string;
         /** an error message or an empty string if no error */
         readonly error: string;
         /** whether the extension has a preferences dialog */
@@ -143,5 +108,41 @@ declare module 'ExtensionMeta' {
         readonly canChange: boolean;
         /** a list of supported session modes */
         readonly sessionModes: string[];
+
+        /**
+         * Open the extension's preferences window
+         */
+        openPreferences(): void;
+    }
+}
+
+declare module 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js' {
+    import type Adw from 'gi://Adw';
+    import type Gtk from 'gi://Gtk';
+
+    import {ExtensionBase} from 'sharedInternals';
+
+    export class ExtensionPreferences extends ExtensionBase {
+        constructor(metadata: ExtensionMetadata) {
+            super(metadata);
+        }
+
+        /**
+         * Fill the preferences window with preferences.
+         *
+         * The default implementation adds the widget
+         * returned by getPreferencesWidget().
+         *
+         * @param {Adw.PreferencesWindow} window - the preferences window
+         */
+        fillPreferencesWindow(window: Adw.PreferencesWindow): void;
+
+        /**
+         * Get the single widget that implements
+         * the extension's preferences.
+         *
+         * @returns {Gtk.Widget}
+         */
+        getPreferencesWidget(): Gtk.Widget;
     }
 }

--- a/types/ui/index.d.ts
+++ b/types/ui/index.d.ts
@@ -4,14 +4,3 @@
 /// <reference path='./main.d.ts' />
 /// <reference path='./panelMenu.d.ts' />
 /// <reference path='./popupMenu.d.ts' />
-
-declare interface GjsUiImports {
-    main: typeof import('main');
-    panelMenu: typeof import('panelMenu');
-    popupMenu: typeof import('popupMenu');
-}
-
-// extend imports interface with ui elements
-declare interface GjsImports {
-    ui: GjsUiImports;
-}

--- a/types/ui/main.d.ts
+++ b/types/ui/main.d.ts
@@ -1,15 +1,16 @@
 /* eslint-disable */
 
-declare module 'main' {
+declare module 'resource:///org/gnome/shell/ui/main.js' {
     import St from 'gi://St';
 
-    import * as PanelMenu from 'panelMenu';
+    import type * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
-    export class Panel extends St.Widget {
-        addToStatusArea(role: string, indicator: PanelMenu.Button, position?: number, box?: unknown): PanelMenu.Button
+    // lazy inline declaration to avoid import chain
+    declare class Panel extends St.Widget {
+        addToStatusArea(role: string, indicator: PanelMenu.Button, position?: number, box?: unknown): PanelMenu.Button;
     }
 
     export function notify(title: string, message: string): void;
 
-    export const panel: Panel;
+    export let panel: Panel;
 }

--- a/types/ui/panelMenu.d.ts
+++ b/types/ui/panelMenu.d.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
 
-declare module 'panelMenu' {
+declare module 'resource:///org/gnome/shell/ui/panelMenu.js' {
     import St from 'gi://St';
 
-    import {PopupMenu} from 'popupMenu';
+    import {PopupMenu} from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
     export class ButtonBox extends St.Widget{}
 

--- a/types/ui/popupMenu.d.ts
+++ b/types/ui/popupMenu.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-declare module 'popupMenu' {
+declare module 'resource:///org/gnome/shell/ui/popupMenu.js' {
     // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js
 
     import Clutter from 'gi://Clutter';


### PR DESCRIPTION
This implements the remaining bits and pieces needed for Gnome45+. In turn, it will make this extension incompatible with Gnome < 45.

Luckily in my previous road to v3 I separated both contexts (background shell/foreground preference window) which is way more implied than before. Both contexts use separate import statements which fail for the other context.
The only module left we're using by both contexts is the settings module. For this to work I had to drag the current contexts' extension import to the settings module.

I'm not sure about the deduplication of both prefs classes. It's making us drag all variables as function parameter because we can't use the constructor anymore. (ec5b0c7b5fc9c8bdafd8de43fe119d9abd7061c0)

fix #172 
fix #177 