### PR TITLE
Remove remaining const classes

### DIFF
--- a/src/historyMenuElements.ts
+++ b/src/historyMenuElements.ts
@@ -47,11 +47,10 @@ class HistoryElement extends PopupMenu.PopupSubMenuMenuItem {
     /**
      * Create a new menu element for a HistoryEntry.
      *
-     * @param {object | undefined} unusedParams Unused params object from the PopupMenu.PopupSubMenuMenuItem
      * @param {HistoryModule.HistoryEntry} historyEntry HistoryEntry this menu element serves
      * @param {number} index Place in history
      */
-    constructor(unusedParams: object | undefined, historyEntry: HistoryModule.HistoryEntry, index: number) {
+    constructor(historyEntry: HistoryModule.HistoryEntry, index: number) {
         super('', false);
 
         this.historyEntry = historyEntry;
@@ -295,11 +294,10 @@ class CurrentImageElement extends HistoryElement {
     /**
      * Create a new image element for the currently active wallpaper.
      *
-     * @param {object | undefined} params Option object of PopupMenu.PopupSubMenuMenuItem
      * @param {HistoryModule.HistoryEntry} historyEntry History entry this menu is for
      */
-    constructor(params: object | undefined, historyEntry: HistoryModule.HistoryEntry) {
-        super(params, historyEntry, 0);
+    constructor(historyEntry: HistoryModule.HistoryEntry) {
+        super(historyEntry, 0);
 
         if (this._setAsWallpaperItem)
             this._setAsWallpaperItem.destroy();
@@ -323,11 +321,9 @@ class NewWallpaperElement extends PopupMenu.PopupBaseMenuItem {
 
     /**
      * Create a button for fetching new wallpaper
-     *
-     * @param {object | undefined} params Options object of PopupMenu.PopupBaseMenuItem
      */
-    constructor(params: object | undefined) {
-        super(params);
+    constructor() {
+        super(undefined);
 
         const container = new St.BoxLayout({
             vertical: true,
@@ -466,7 +462,7 @@ class HistorySection extends PopupMenu.PopupMenuSection {
 
             let cachedHistoryElement = this._historySectionCache.get(historyID);
             if (!cachedHistoryElement) {
-                cachedHistoryElement = new HistoryElement(undefined, history[i], i);
+                cachedHistoryElement = new HistoryElement(history[i], i);
                 cachedHistoryElement.actor.connect('key-focus-in', onEnter);
                 cachedHistoryElement.actor.connect('key-focus-out', onLeave);
                 cachedHistoryElement.actor.connect('enter-event', onEnter);

--- a/src/historyMenuElements.ts
+++ b/src/historyMenuElements.ts
@@ -19,10 +19,19 @@ import {Logger} from './logger.js';
 Gio._promisify(Gio.File.prototype, 'copy_async', 'copy_finish');
 Gio._promisify(Gio.File.prototype, 'replace_contents_bytes_async', 'replace_contents_finish');
 
-// GJS style class extending
-const HistoryElement = GObject.registerClass({
-    GTypeName: 'HistoryElement',
-}, class HistoryElement extends PopupMenu.PopupSubMenuMenuItem {
+// FIXME: Generated static class code produces a no-unused-expressions rule error
+/* eslint-disable no-unused-expressions */
+
+/**
+ * Shell menu item holding information related to a HistoryEntry
+ */
+class HistoryElement extends PopupMenu.PopupSubMenuMenuItem {
+    static [GObject.GTypeName] = 'HistoryElement';
+
+    static {
+        GObject.registerClass(this);
+    }
+
     private _settings = new Settings.Settings();
 
     private _prefixLabel;
@@ -271,11 +280,18 @@ const HistoryElement = GObject.registerClass({
     setIndex(index: number): void {
         this._prefixLabel.set_text(`${String(index)}.`);
     }
-});
+}
 
-const CurrentImageElement = GObject.registerClass({
-    GTypeName: 'CurrentImageElement',
-}, class CurrentImageElement extends HistoryElement {
+/**
+ * Special shell menu element for the current wallpaper HistoryEntry
+ */
+class CurrentImageElement extends HistoryElement {
+    static [GObject.GTypeName] = 'CurrentImageElement';
+
+    static {
+        GObject.registerClass(this);
+    }
+
     /**
      * Create a new image element for the currently active wallpaper.
      *
@@ -288,17 +304,20 @@ const CurrentImageElement = GObject.registerClass({
         if (this._setAsWallpaperItem)
             this._setAsWallpaperItem.destroy();
     }
-});
+}
 
 /**
  * Element for the "New Wallpaper" button and the remaining time for the auto fetch
  * feature.
  * The remaining time will only be displayed if the af-feature is activated.
  */
-const NewWallpaperElement = GObject.registerClass({
-    GTypeName: 'NewWallpaperElement',
-},
 class NewWallpaperElement extends PopupMenu.PopupBaseMenuItem {
+    static [GObject.GTypeName] = 'NewWallpaperElement';
+
+    static {
+        GObject.registerClass(this);
+    }
+
     private _timer = Timer.getTimer();
     private _remainingLabel;
 
@@ -353,7 +372,7 @@ class NewWallpaperElement extends PopupMenu.PopupBaseMenuItem {
             this._remainingLabel.hide();
         }
     }
-});
+}
 
 /**
  * The status element in the Gnome Shell top panel bar.
@@ -403,7 +422,7 @@ class HistorySection extends PopupMenu.PopupMenuSection {
     /**
      * Cache HistoryElements for performance of long histories.
      */
-    private _historySectionCache = new Map<string, InstanceType<typeof HistoryElement>>();
+    private _historySectionCache = new Map<string, HistoryElement>();
     private _historyCache: HistoryModule.HistoryEntry[] = [];
 
     /**
@@ -430,9 +449,9 @@ class HistorySection extends PopupMenu.PopupMenuSection {
      */
     updateList(
         history: HistoryModule.HistoryEntry[],
-        onEnter: (actor: InstanceType<typeof HistoryElement>) => void,
-        onLeave: (actor: InstanceType<typeof HistoryElement>) => void,
-        onSelect: (actor: InstanceType<typeof HistoryElement>) => void
+        onEnter: (actor: HistoryElement) => void,
+        onLeave: (actor: HistoryElement) => void,
+        onSelect: (actor: HistoryElement) => void
     ): void {
         if (this._historyCache.length <= 1)
             this.removeAll(); // remove empty history element

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -116,7 +116,7 @@ class RandomWallpaperSettings extends ExtensionPreferences {
         window.add(builder.get_object('page_sources'));
 
         sources.forEach(id => {
-            const sourceRow = new SourceRow(undefined, id);
+            const sourceRow = new SourceRow(id);
             builder.get_object<Adw.PreferencesGroup>('sources_list').add(sourceRow);
 
             sourceRow.button_delete.connect('clicked', () => {
@@ -162,7 +162,7 @@ class RandomWallpaperSettings extends ExtensionPreferences {
 
         const sourceRowList = builder.get_object<Adw.PreferencesGroup>('sources_list');
         builder.get_object('button_new_source').connect('clicked', () => {
-            const sourceRow = new SourceRow(undefined, null);
+            const sourceRow = new SourceRow(null);
             sourceRowList.add(sourceRow);
             sources.push(String(sourceRow.id));
             this._saveSources(settings, sources);

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -5,11 +5,11 @@ import Gtk from 'gi://Gtk';
 import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 import * as Settings from './settings.js';
-import * as SourceRow from './ui/sourceRow.js';
 import * as Utils from './utils.js';
 import * as WallpaperManager from './manager/wallpaperManager.js';
 
 import {Logger} from './logger.js';
+import {SourceRow} from './ui/sourceRow.js';
 
 // https://gjs.guide/extensions/overview/anatomy.html#prefs-js
 // The code in prefs.js will be executed in a separate Gtk process
@@ -116,7 +116,7 @@ class RandomWallpaperSettings extends ExtensionPreferences {
         window.add(builder.get_object('page_sources'));
 
         sources.forEach(id => {
-            const sourceRow = new SourceRow.SourceRow(undefined, id);
+            const sourceRow = new SourceRow(undefined, id);
             builder.get_object<Adw.PreferencesGroup>('sources_list').add(sourceRow);
 
             sourceRow.button_delete.connect('clicked', () => {
@@ -162,7 +162,7 @@ class RandomWallpaperSettings extends ExtensionPreferences {
 
         const sourceRowList = builder.get_object<Adw.PreferencesGroup>('sources_list');
         builder.get_object('button_new_source').connect('clicked', () => {
-            const sourceRow = new SourceRow.SourceRow();
+            const sourceRow = new SourceRow(undefined, null);
             sourceRowList.add(sourceRow);
             sources.push(String(sourceRow.id));
             this._saveSources(settings, sources);

--- a/src/randomWallpaperMenu.ts
+++ b/src/randomWallpaperMenu.ts
@@ -242,10 +242,10 @@ class RandomWallpaperMenu {
         /**
          * Function for events that should happen on element leave.
          *
-         * @param {InstanceType<typeof CustomElements.HistoryElement>} unusedActor The activating panel item
+         * @param {CustomElements.HistoryElement} unusedActor The activating panel item
          * @this RandomWallpaperMenu
          */
-        function onLeave(this: RandomWallpaperMenu, unusedActor: InstanceType<typeof CustomElements.HistoryElement>): void {
+        function onLeave(this: RandomWallpaperMenu, unusedActor: CustomElements.HistoryElement): void {
             if (!this._wallpaperController.prohibitNewWallpaper && this._savedBackgroundUri)
                 this._wallpaperController.resetWallpaper(this._savedBackgroundUri);
         }
@@ -253,10 +253,10 @@ class RandomWallpaperMenu {
         /**
          * Function for events that should happen on element enter.
          *
-         * @param {InstanceType<typeof CustomElements.HistoryElement>} actor The activating panel item
+         * @param {CustomElements.HistoryElement} actor The activating panel item
          * @this RandomWallpaperMenu
          */
-        function onEnter(this: RandomWallpaperMenu, actor: InstanceType<typeof CustomElements.HistoryElement>): void {
+        function onEnter(this: RandomWallpaperMenu, actor: CustomElements.HistoryElement): void {
             if (!this._wallpaperController.prohibitNewWallpaper)
                 this._wallpaperController.previewWallpaper(actor.historyEntry.id);
         }
@@ -264,10 +264,10 @@ class RandomWallpaperMenu {
         /**
          * Function for events that should happen on element select.
          *
-         * @param {InstanceType<typeof CustomElements.HistoryElement>} actor The activating panel item
+         * @param {CustomElements.HistoryElement} actor The activating panel item
          * @this RandomWallpaperMenu
          */
-        function onSelect(this: RandomWallpaperMenu, actor: InstanceType<typeof CustomElements.HistoryElement>): void {
+        function onSelect(this: RandomWallpaperMenu, actor: CustomElements.HistoryElement): void {
             // Make sure no other preview or reset event overwrites our setWallpaper!
             this._wallpaperController.prohibitNewWallpaper = true;
 

--- a/src/randomWallpaperMenu.ts
+++ b/src/randomWallpaperMenu.ts
@@ -51,7 +51,7 @@ class RandomWallpaperMenu {
         this._observedValues.push(this._settings.observe('hide-panel-icon', this.updatePanelMenuVisibility.bind(this)));
 
         // new wallpaper button
-        const newWallpaperItem = new CustomElements.NewWallpaperElement({});
+        const newWallpaperItem = new CustomElements.NewWallpaperElement();
         this._panelMenu.menu.addMenuItem(newWallpaperItem);
 
         this._panelMenu.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
@@ -219,7 +219,7 @@ class RandomWallpaperMenu {
         const history = historyController.history;
 
         if (history.length > 0) {
-            const currentImage = new CustomElements.CurrentImageElement(undefined, history[0]);
+            const currentImage = new CustomElements.CurrentImageElement(history[0]);
             this._currentBackgroundSection.addMenuItem(currentImage);
         }
     }

--- a/src/ui/genericJson.ts
+++ b/src/ui/genericJson.ts
@@ -51,11 +51,10 @@ class GenericJsonSettingsGroup extends Adw.PreferencesGroup {
      *
      * Previously saved settings will be used if the adapter and ID match.
      *
-     * @param {Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined} params Properties for Adw.PreferencesGroup or undefined
      * @param {string} id Unique ID
      */
-    constructor(params: Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined, id: string) {
-        super(params);
+    constructor(id: string) {
+        super(undefined);
 
         const path = `${Settings.RWG_SETTINGS_SCHEMA_PATH}/sources/genericJSON/${id}/`;
         this._settings = new Settings.Settings(Settings.RWG_SETTINGS_SCHEMA_SOURCES_GENERIC_JSON, path);

--- a/src/ui/genericJson.ts
+++ b/src/ui/genericJson.ts
@@ -2,13 +2,22 @@ import Adw from 'gi://Adw';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
 
 import * as Settings from './../settings.js';
 
-const GenericJsonSettingsGroup = GObject.registerClass({
-    GTypeName: 'GenericJsonSettingsGroup',
-    Template: GLib.uri_resolve_relative(import.meta.url, './genericJson.ui', GLib.UriFlags.NONE),
-    InternalChildren: [
+// FIXME: Generated static class code produces a no-unused-expressions rule error
+/* eslint-disable no-unused-expressions */
+
+/**
+ * Subclass containing the preferences group for GenericJson adapter
+ */
+class GenericJsonSettingsGroup extends Adw.PreferencesGroup {
+    static [GObject.GTypeName] = 'GenericJsonSettingsGroup';
+    // @ts-expect-error Gtk.template is not in the type definitions files yet
+    static [Gtk.template] = GLib.uri_resolve_relative(import.meta.url, './genericJson.ui', GLib.UriFlags.NONE);
+    // @ts-expect-error Gtk.internalChildren is not in the type definitions files yet
+    static [Gtk.internalChildren] = [
         'author_name_path',
         'author_url_path',
         'author_url_prefix',
@@ -18,8 +27,12 @@ const GenericJsonSettingsGroup = GObject.registerClass({
         'post_path',
         'post_prefix',
         'request_url',
-    ],
-}, class GenericJsonSettingsGroup extends Adw.PreferencesGroup {
+    ];
+
+    static {
+        GObject.registerClass(this);
+    }
+
     // InternalChildren
     private _author_name_path!: Adw.EntryRow;
     private _author_url_path!: Adw.EntryRow;
@@ -91,6 +104,6 @@ const GenericJsonSettingsGroup = GObject.registerClass({
     clearConfig(): void {
         this._settings.resetSchema();
     }
-});
+}
 
 export {GenericJsonSettingsGroup};

--- a/src/ui/localFolder.ts
+++ b/src/ui/localFolder.ts
@@ -38,11 +38,10 @@ class LocalFolderSettingsGroup extends Adw.PreferencesGroup {
      *
      * Previously saved settings will be used if the adapter and ID match.
      *
-     * @param {Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined} params Properties for Adw.PreferencesGroup or undefined
      * @param {string} id Unique ID
      */
-    constructor(params: Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined, id: string) {
-        super(params);
+    constructor(id: string) {
+        super(undefined);
 
         const path = `${Settings.RWG_SETTINGS_SCHEMA_PATH}/sources/localFolder/${id}/`;
         this._settings = new Settings.Settings(Settings.RWG_SETTINGS_SCHEMA_SOURCES_LOCAL_FOLDER, path);

--- a/src/ui/localFolder.ts
+++ b/src/ui/localFolder.ts
@@ -6,14 +6,26 @@ import Gtk from 'gi://Gtk';
 
 import * as Settings from './../settings.js';
 
-const LocalFolderSettingsGroup = GObject.registerClass({
-    GTypeName: 'LocalFolderSettingsGroup',
-    Template: GLib.uri_resolve_relative(import.meta.url, './localFolder.ui', GLib.UriFlags.NONE),
-    InternalChildren: [
+// FIXME: Generated static class code produces a no-unused-expressions rule error
+/* eslint-disable no-unused-expressions */
+
+/**
+ * Subclass containing the preferences group for LocalFolder adapter
+ */
+class LocalFolderSettingsGroup extends Adw.PreferencesGroup {
+    static [GObject.GTypeName] = 'LocalFolderSettingsGroup';
+    // @ts-expect-error Gtk.template is not in the type definitions files yet
+    static [Gtk.template] = GLib.uri_resolve_relative(import.meta.url, './localFolder.ui', GLib.UriFlags.NONE);
+    // @ts-expect-error Gtk.internalChildren is not in the type definitions files yet
+    static [Gtk.internalChildren] = [
         'folder',
         'folder_row',
-    ],
-}, class LocalFolderSettingsGroup extends Adw.PreferencesGroup {
+    ];
+
+    static {
+        GObject.registerClass(this);
+    }
+
     // InternalChildren
     private _folder!: Gtk.Button;
     private _folder_row!: Adw.EntryRow;
@@ -76,6 +88,6 @@ const LocalFolderSettingsGroup = GObject.registerClass({
     clearConfig(): void {
         this._settings.resetSchema();
     }
-});
+}
 
 export {LocalFolderSettingsGroup};

--- a/src/ui/reddit.ts
+++ b/src/ui/reddit.ts
@@ -6,18 +6,30 @@ import Gtk from 'gi://Gtk';
 
 import * as Settings from './../settings.js';
 
-const RedditSettingsGroup = GObject.registerClass({
-    GTypeName: 'RedditSettingsGroup',
-    Template: GLib.uri_resolve_relative(import.meta.url, './reddit.ui', GLib.UriFlags.NONE),
-    InternalChildren: [
+// FIXME: Generated static class code produces a no-unused-expressions rule error
+/* eslint-disable no-unused-expressions */
+
+/**
+ * Subclass containing the preferences group for Reddit adapter
+ */
+class RedditSettingsGroup extends Adw.PreferencesGroup {
+    static [GObject.GTypeName] = 'RedditSettingsGroup';
+    // @ts-expect-error Gtk.template is not in the type definitions files yet
+    static [Gtk.template] = GLib.uri_resolve_relative(import.meta.url, './reddit.ui', GLib.UriFlags.NONE);
+    // @ts-expect-error Gtk.internalChildren is not in the type definitions files yet
+    static [Gtk.internalChildren] = [
         'allow_sfw',
         'image_ratio1',
         'image_ratio2',
         'min_height',
         'min_width',
         'subreddits',
-    ],
-}, class RedditSettingsGroup extends Adw.PreferencesGroup {
+    ];
+
+    static {
+        GObject.registerClass(this);
+    }
+
     // InternalChildren
     private _allow_sfw!: Gtk.Switch;
     private _image_ratio1!: Gtk.Adjustment;
@@ -74,6 +86,6 @@ const RedditSettingsGroup = GObject.registerClass({
     clearConfig(): void {
         this._settings.resetSchema();
     }
-});
+}
 
 export {RedditSettingsGroup};

--- a/src/ui/reddit.ts
+++ b/src/ui/reddit.ts
@@ -45,11 +45,10 @@ class RedditSettingsGroup extends Adw.PreferencesGroup {
      *
      * Previously saved settings will be used if the adapter and ID match.
      *
-     * @param {Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined} params Properties for Adw.PreferencesGroup or undefined
      * @param {string} id Unique ID
      */
-    constructor(params: Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined, id: string) {
-        super(params);
+    constructor(id: string) {
+        super(undefined);
 
         const path = `${Settings.RWG_SETTINGS_SCHEMA_PATH}/sources/reddit/${id}/`;
         this._settings = new Settings.Settings(Settings.RWG_SETTINGS_SCHEMA_SOURCES_REDDIT, path);

--- a/src/ui/sourceRow.ts
+++ b/src/ui/sourceRow.ts
@@ -65,11 +65,10 @@ class SourceRow extends Adw.ExpanderRow {
      * Default unique ID is Date.now()
      * Previously saved settings will be used if the ID matches.
      *
-     * @param {Partial<Adw.ExpanderRow.ConstructorProperties> | undefined} params Properties for Adw.ExpanderRow or undefined
      * @param {string | null} id Unique ID or null
      */
-    constructor(params: Partial<Adw.ExpanderRow.ConstructorProperties> | undefined, id?: string | null) {
-        super(params);
+    constructor(id?: string | null) {
+        super(undefined);
 
         if (id)
             this.id = id;
@@ -159,22 +158,22 @@ class SourceRow extends Adw.ExpanderRow {
         let targetWidget = null;
         switch (type) {
         case Utils.SourceType.UNSPLASH:
-            targetWidget = new UnsplashSettingsGroup(undefined, this.id);
+            targetWidget = new UnsplashSettingsGroup(this.id);
             break;
         case Utils.SourceType.WALLHAVEN:
-            targetWidget = new WallhavenSettingsGroup(undefined, this.id);
+            targetWidget = new WallhavenSettingsGroup(this.id);
             break;
         case Utils.SourceType.REDDIT:
-            targetWidget = new RedditSettingsGroup(undefined, this.id);
+            targetWidget = new RedditSettingsGroup(this.id);
             break;
         case Utils.SourceType.GENERIC_JSON:
-            targetWidget = new GenericJsonSettingsGroup(undefined, this.id);
+            targetWidget = new GenericJsonSettingsGroup(this.id);
             break;
         case Utils.SourceType.LOCAL_FOLDER:
-            targetWidget = new LocalFolderSettingsGroup(undefined, this.id);
+            targetWidget = new LocalFolderSettingsGroup(this.id);
             break;
         case Utils.SourceType.STATIC_URL:
-            targetWidget = new UrlSourceSettingsGroup(undefined, this.id);
+            targetWidget = new UrlSourceSettingsGroup(this.id);
             break;
         default:
             targetWidget = null;

--- a/src/ui/sourceRow.ts
+++ b/src/ui/sourceRow.ts
@@ -16,20 +16,33 @@ import {UnsplashSettingsGroup} from './unsplash.js';
 import {UrlSourceSettingsGroup} from './urlSource.js';
 import {WallhavenSettingsGroup} from './wallhaven.js';
 
-// https://gitlab.gnome.org/GNOME/gjs/-/blob/master/examples/gtk4-template.js
-const SourceRow = GObject.registerClass({
-    GTypeName: 'SourceRow',
-    Template: GLib.uri_resolve_relative(import.meta.url, './sourceRow.ui', GLib.UriFlags.NONE),
-    Children: [
+// FIXME: Generated static class code produces a no-unused-expressions rule error
+/* eslint-disable no-unused-expressions */
+
+/**
+ * Class containing general settings for each adapter source as well as the adapter source
+ */
+class SourceRow extends Adw.ExpanderRow {
+    static [GObject.GTypeName] = 'SourceRow';
+    // @ts-expect-error Gtk.template is not in the type definitions files yet
+    static [Gtk.template] = GLib.uri_resolve_relative(import.meta.url, './sourceRow.ui', GLib.UriFlags.NONE);
+    // @ts-expect-error Gtk.children is not in the type definitions files yet
+    static [Gtk.children] = [
         'button_delete',
-    ],
-    InternalChildren: [
+    ];
+
+    // @ts-expect-error Gtk.internalChildren is not in the type definitions files yet
+    static [Gtk.internalChildren] = [
         'blocked_images_list',
         'combo',
         'settings_container',
         'source_name',
-    ],
-}, class SourceRow extends Adw.ExpanderRow {
+    ];
+
+    static {
+        GObject.registerClass(this);
+    }
+
     // This list is the same across all rows
     static _stringList: Gtk.StringList;
 
@@ -134,15 +147,15 @@ const SourceRow = GObject.registerClass({
      * Get a new adapter based on an enum source type.
      *
      * @param {Utils.SourceType} type Enum of the adapter to get
-     * @returns {object | null} Newly crafted adapter or null
+     * @returns {UnsplashSettingsGroup | WallhavenSettingsGroup | RedditSettingsGroup | GenericJsonSettingsGroup | LocalFolderSettingsGroup | UrlSourceSettingsGroup | null} Newly crafted adapter or null
      */
-    private _getSettingsGroup(type: Utils.SourceType = Utils.SourceType.UNSPLASH): GObject.RegisteredPrototype<InstanceType<typeof UnsplashSettingsGroup>, { [key: string]: GObject.ParamSpec<unknown>; }, unknown[]>
-     | GObject.RegisteredPrototype<InstanceType<typeof WallhavenSettingsGroup>, { [key: string]: GObject.ParamSpec<unknown>; }, unknown[]>
-     | GObject.RegisteredPrototype<InstanceType<typeof RedditSettingsGroup>, { [key: string]: GObject.ParamSpec<unknown>; }, unknown[]>
-     | GObject.RegisteredPrototype<InstanceType<typeof GenericJsonSettingsGroup>, { [key: string]: GObject.ParamSpec<unknown>; }, unknown[]>
-     | GObject.RegisteredPrototype<InstanceType<typeof LocalFolderSettingsGroup>, { [key: string]: GObject.ParamSpec<unknown>; }, unknown[]>
-     | GObject.RegisteredPrototype<InstanceType<typeof UrlSourceSettingsGroup>, { [key: string]: GObject.ParamSpec<unknown>; }, unknown[]>
-     | null {
+    private _getSettingsGroup(type: Utils.SourceType = Utils.SourceType.UNSPLASH): UnsplashSettingsGroup
+        | WallhavenSettingsGroup
+        | RedditSettingsGroup
+        | GenericJsonSettingsGroup
+        | LocalFolderSettingsGroup
+        | UrlSourceSettingsGroup
+        | null {
         let targetWidget = null;
         switch (type) {
         case Utils.SourceType.UNSPLASH:
@@ -198,6 +211,6 @@ const SourceRow = GObject.registerClass({
 
         this._settings.resetSchema();
     }
-});
+}
 
 export {SourceRow};

--- a/src/ui/unsplash.ts
+++ b/src/ui/unsplash.ts
@@ -58,11 +58,10 @@ class UnsplashSettingsGroup extends Adw.PreferencesGroup {
      *
      * Previously saved settings will be used if the adapter and ID match.
      *
-     * @param {Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined} params Properties for Adw.PreferencesGroup or undefined
      * @param {string} id Unique ID
      */
-    constructor(params: Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined, id: string) {
-        super(params);
+    constructor(id: string) {
+        super(undefined);
 
         const path = `${Settings.RWG_SETTINGS_SCHEMA_PATH}/sources/unsplash/${id}/`;
         this._settings = new Settings.Settings(Settings.RWG_SETTINGS_SCHEMA_SOURCES_UNSPLASH, path);

--- a/src/ui/unsplash.ts
+++ b/src/ui/unsplash.ts
@@ -16,20 +16,25 @@ enum ConstraintType {
 }
 /* eslint-enable */
 
-const UnsplashSettingsGroup = GObject.registerClass({
-    GTypeName: 'UnsplashSettingsGroup',
-    Template: GLib.uri_resolve_relative(import.meta.url, './unsplash.ui', GLib.UriFlags.NONE),
-    InternalChildren: [
+// FIXME: Generated static class code produces a no-unused-expressions rule error
+/* eslint-disable no-unused-expressions */
+
+/**
+ * Subclass containing the preferences group for Unsplash adapter
+ */
+class UnsplashSettingsGroup extends Adw.PreferencesGroup {
+    static [GObject.GTypeName] = 'UnsplashSettingsGroup';
+    // @ts-expect-error Gtk.template is not in the type definitions files yet
+    static [Gtk.template] = GLib.uri_resolve_relative(import.meta.url, './unsplash.ui', GLib.UriFlags.NONE);
+    // @ts-expect-error Gtk.internalChildren is not in the type definitions files yet
+    static [Gtk.internalChildren] = [
         'constraint_type',
         'constraint_value',
         'featured_only',
         'image_height',
         'image_width',
         'keyword',
-    ],
-}, class UnsplashSettingsGroup extends Adw.PreferencesGroup {
-    // This list is the same across all rows
-    static _stringList: Gtk.StringList;
+    ];
 
     // InternalChildren
     private _constraint_type!: Adw.ComboRow;
@@ -38,6 +43,13 @@ const UnsplashSettingsGroup = GObject.registerClass({
     private _image_height!: Gtk.Adjustment;
     private _image_width!: Gtk.Adjustment;
     private _keyword!: Adw.EntryRow;
+
+    static {
+        GObject.registerClass(this);
+    }
+
+    // This list is the same across all rows
+    static _stringList: Gtk.StringList;
 
     private _settings;
 
@@ -115,7 +127,7 @@ const UnsplashSettingsGroup = GObject.registerClass({
     clearConfig(): void {
         this._settings.resetSchema();
     }
-});
+}
 
 /**
  * Retrieve the human readable enum name.

--- a/src/ui/urlSource.ts
+++ b/src/ui/urlSource.ts
@@ -45,11 +45,10 @@ class UrlSourceSettingsGroup extends Adw.PreferencesGroup {
      *
      * Previously saved settings will be used if the adapter and ID match.
      *
-     * @param {Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined} params Properties for Adw.PreferencesGroup or undefined
      * @param {string} id Unique ID
      */
-    constructor(params: Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined, id: string) {
-        super(params);
+    constructor(id: string) {
+        super(undefined);
 
         const path = `${Settings.RWG_SETTINGS_SCHEMA_PATH}/sources/urlSource/${id}/`;
         this._settings = new Settings.Settings(Settings.RWG_SETTINGS_SCHEMA_SOURCES_URL_SOURCE, path);

--- a/src/ui/urlSource.ts
+++ b/src/ui/urlSource.ts
@@ -6,18 +6,30 @@ import Gtk from 'gi://Gtk';
 
 import * as Settings from './../settings.js';
 
-const UrlSourceSettingsGroup = GObject.registerClass({
-    GTypeName: 'UrlSourceSettingsGroup',
-    Template: GLib.uri_resolve_relative(import.meta.url, './urlSource.ui', GLib.UriFlags.NONE),
-    InternalChildren: [
+// FIXME: Generated static class code produces a no-unused-expressions rule error
+/* eslint-disable no-unused-expressions */
+
+/**
+ * Subclass containing the preferences group for UrlSource adapter
+ */
+class UrlSourceSettingsGroup extends Adw.PreferencesGroup {
+    static [GObject.GTypeName] = 'UrlSourceSettingsGroup';
+    // @ts-expect-error Gtk.template is not in the type definitions files yet
+    static [Gtk.template] = GLib.uri_resolve_relative(import.meta.url, './urlSource.ui', GLib.UriFlags.NONE);
+    // @ts-expect-error Gtk.internalChildren is not in the type definitions files yet
+    static [Gtk.internalChildren] = [
         'author_name',
         'author_url',
         'different_images',
         'domain',
         'image_url',
         'post_url',
-    ],
-}, class UrlSourceSettingsGroup extends Adw.PreferencesGroup {
+    ];
+
+    static {
+        GObject.registerClass(this);
+    }
+
     // InternalChildren
     private _author_name!: Adw.EntryRow;
     private _author_url!: Adw.EntryRow;
@@ -74,6 +86,6 @@ const UrlSourceSettingsGroup = GObject.registerClass({
     clearConfig(): void {
         this._settings.resetSchema();
     }
-});
+}
 
 export {UrlSourceSettingsGroup};

--- a/src/ui/wallhaven.ts
+++ b/src/ui/wallhaven.ts
@@ -7,10 +7,18 @@ import Gtk from 'gi://Gtk';
 
 import * as Settings from './../settings.js';
 
-const WallhavenSettingsGroup = GObject.registerClass({
-    GTypeName: 'WallhavenSettingsGroup',
-    Template: GLib.uri_resolve_relative(import.meta.url, './wallhaven.ui', GLib.UriFlags.NONE),
-    InternalChildren: [
+// FIXME: Generated static class code produces a no-unused-expressions rule error
+/* eslint-disable no-unused-expressions */
+
+/**
+ * Subclass containing the preferences group for Wallhaven adapter
+ */
+class WallhavenSettingsGroup extends Adw.PreferencesGroup {
+    static [GObject.GTypeName] = 'WallhavenSettingsGroup';
+    // @ts-expect-error Gtk.template is not in the type definitions files yet
+    static [Gtk.template] = GLib.uri_resolve_relative(import.meta.url, './wallhaven.ui', GLib.UriFlags.NONE);
+    // @ts-expect-error Gtk.internalChildren is not in the type definitions files yet
+    static [Gtk.internalChildren] = [
         'ai_art',
         'allow_nsfw',
         'allow_sfw',
@@ -25,8 +33,12 @@ const WallhavenSettingsGroup = GObject.registerClass({
         'keyword',
         'minimal_resolution',
         'row_color',
-    ],
-}, class WallhavenSettingsGroup extends Adw.PreferencesGroup {
+    ];
+
+    static {
+        GObject.registerClass(this);
+    }
+
     private static _colorPalette: Gdk.RGBA[];
     private static _availableColors: string[] = [
         '#660000', '#990000', '#cc0000', '#cc3333', '#ea4c88',
@@ -171,6 +183,6 @@ const WallhavenSettingsGroup = GObject.registerClass({
     clearConfig(): void {
         this._settings.resetSchema();
     }
-});
+}
 
 export {WallhavenSettingsGroup};

--- a/src/ui/wallhaven.ts
+++ b/src/ui/wallhaven.ts
@@ -73,11 +73,10 @@ class WallhavenSettingsGroup extends Adw.PreferencesGroup {
      *
      * Previously saved settings will be used if the adapter and ID match.
      *
-     * @param {Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined} params Properties for Adw.PreferencesGroup or undefined
      * @param {string} id Unique ID
      */
-    constructor(params: Partial<Adw.PreferencesGroup.ConstructorProperties> | undefined, id: string) {
-        super(params);
+    constructor(id: string) {
+        super(undefined);
 
         const path = `${Settings.RWG_SETTINGS_SCHEMA_PATH}/sources/wallhaven/${id}/`;
         this._settings = new Settings.Settings(Settings.RWG_SETTINGS_SCHEMA_SOURCES_WALLHAVEN, path);


### PR DESCRIPTION
This removes the remaining const classes which were needed for `GObject.registerClass()` before.
The same can be achieved with the yet undocumented static class features of GObject: https://gitlab.gnome.org/ewlsh/gjs-guide/-/issues/72

Unfortunately the *generated code* has a quirk not liked by eslint and triggers the rule [`no-unused-expressions`](https://eslint.org/docs/latest/rules/no-unused-expressions) and I'm not sure why. I've disabled the rule for the affected files for now.

~~~ js
var _a, _b, _c, _d;
…
// The following line produces the linting error
_a = GenericJsonSettingsGroup, _b = GObject.GTypeName, _c = Gtk.template, _d = Gtk.internalChildren;
…
(() => {
    GObject.registerClass(_a);
})();
~~~