### PR TITLE
Change default User-Agent to `RandomWallpaperGnome3/3.0`

### DIFF
--- a/src/soupBowl.ts
+++ b/src/soupBowl.ts
@@ -38,7 +38,7 @@ class SoupBowl {
     newGetMessage(uri: string): Soup.Message {
         const message = Soup.Message.new('GET', uri);
         // set User-Agent to appear more like a standard browser
-        message.request_headers.append('User-Agent', 'Mozilla/5.0');
+        message.request_headers.append('User-Agent', 'RandomWallpaperGnome3/3.0');
         return message;
     }
 


### PR DESCRIPTION
While testing my various configured sources for the initial genericjson improvements again, I stumbled upon a source which doesn't work for the default `Mozilla/5.0` User-Agent. The site is protected by Cloudflare and I assume that the User-Agent `Mozilla/5.0` lets Cloudflare believe that JavaScript should be available and tries to test it with an anti bot challenge.
Using a different string as the User-Agent goes around this test - I only tested this with `RandomWallpaperGnome3/3.0`.

~~~
Failing:
$ http "https://danbooru.donmai.us/posts.json?tags=rating:general" User-Agent:Mozilla/5.0

Working:
$ http "https://danbooru.donmai.us/posts.json?tags=rating:general" User-Agent:RandomWallpaperGnome3/3.0
~~~

As a first thought I added a simple input to the configuration which lets the user override the User-Agent if necessary and falls back to the default if not set.

Reference: https://github.com/ifl0w/RandomWallpaperGnome3/pull/174#discussion_r1355676741