### PR TITLE
Single preview widget for all history elements

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -208,8 +208,7 @@ class HistoryController {
     clear(): void {
         const firstHistoryElement = this.history[0];
 
-        if (firstHistoryElement)
-            this.history = [firstHistoryElement];
+        this.history = [];
 
         const directory = Gio.file_new_for_path(_wallpaperLocation);
         const enumerator = directory.enumerate_children('', Gio.FileQueryInfoFlags.NONE, null);

--- a/src/historyMenuElements.ts
+++ b/src/historyMenuElements.ts
@@ -229,7 +229,7 @@ class HistoryElement extends PopupMenu.PopupSubMenuMenuItem {
                 this.menu.addMenuItem(sourceItem);
             }
 
-            const imageUrlItem = new PopupMenu.PopupMenuItem('Open Image In Browser');
+            const imageUrlItem = new PopupMenu.PopupMenuItem('Open Image in Browser');
             imageUrlItem.connect('activate', () => {
                 if (this.historyEntry.source.imageLinkUrl) {
                     Utils.execCheck(['xdg-open', this.historyEntry.source.imageLinkUrl]).catch(error => {
@@ -240,7 +240,7 @@ class HistoryElement extends PopupMenu.PopupSubMenuMenuItem {
 
             this.menu.addMenuItem(imageUrlItem);
         } else {
-            this.menu.addMenuItem(new PopupMenu.PopupMenuItem('Unknown source.'));
+            this.menu.addMenuItem(new PopupMenu.PopupMenuItem('Unknown Source'));
         }
 
         this.menu.addMenuItem(new HistoryElementSubmenuSeparator());
@@ -275,7 +275,7 @@ class HistoryElement extends PopupMenu.PopupSubMenuMenuItem {
 
         // Static URLs can't block images (yet?)
         if (this.historyEntry.adapter?.type !== Utils.SourceType.STATIC_URL) {
-            const blockImage = new PopupMenu.PopupMenuItem('Add To Blocklist');
+            const blockImage = new PopupMenu.PopupMenuItem('Add to Blocklist');
             blockImage.connect('activate', () => {
                 this._addToBlocklist();
             });

--- a/src/historyMenuElements.ts
+++ b/src/historyMenuElements.ts
@@ -250,7 +250,6 @@ class HistoryElement extends PopupMenu.PopupSubMenuMenuItem {
             this.emit('activate', null); // Fixme: not sure what the second parameter should be. null seems to work fine for now.
         });
 
-        // this.menu.addMenuItem(new PopupMenu.PopupBaseMenuItem({ can_focus: false, reactive: false })); // theme independent spacing
         this.menu.addMenuItem(this._setAsWallpaperItem);
 
         const copyToFavorites = new PopupMenu.PopupMenuItem('Save For Later');

--- a/src/historyMenuElements.ts
+++ b/src/historyMenuElements.ts
@@ -549,14 +549,10 @@ class HistorySection extends PopupMenu.PopupMenuSection {
      */
     clear(): void {
         this.removeAll();
-        this.addMenuItem(
-            new PopupMenu.PopupMenuItem('No recent wallpaper ...', {
-                activate: false,
-                hover: false,
-                style_class: 'rwg-recent-label',
-                can_focus: false,
-            })
-        );
+
+        const noHistory = new PopupMenu.PopupMenuItem('No Wallpaper History');
+        noHistory.sensitive = false;
+        this.addMenuItem(noHistory);
     }
 }
 

--- a/src/historyMenuElements.ts
+++ b/src/historyMenuElements.ts
@@ -508,8 +508,8 @@ class HistorySection extends PopupMenu.PopupMenuSection {
         super();
 
         this.actor = new St.ScrollView({
-            hscrollbar_policy: St.PolicyType.NEVER,
             vscrollbar_policy: St.PolicyType.AUTOMATIC,
+            overlay_scrollbars: true,
         });
 
         this.actor.add_actor(this.box);

--- a/src/historyMenuElements.ts
+++ b/src/historyMenuElements.ts
@@ -270,6 +270,22 @@ class HistoryElement extends PopupMenu.PopupSubMenuMenuItem {
             });
             this.menu.addMenuItem(blockImage);
         }
+
+        // The private function _needsScrollbar defines whether a scrollbar is added to the sub-menu.
+        // It is overwritten here since this forces the sub-menu to expand to its natural height.
+        // Otherwise, with long histories, the scrollView is very narrow and scrolling in it isn't really possible.
+        // The outer scrollView encapsulating all history entries should be the only scrollable element.
+        // Source: https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/c76b18a04282e48f6196ad1f9f1ab6f08c492599/js/ui/popupMenu.js#L1028-1035
+        //
+        // FIXME: Need to find a proper solution to this problem since this approach might eventually break. Setting "max-height" in CSS
+        // on the right element should work as well but didn't work for me for some reason.
+        // @ts-expect-error private function overwritten
+        this.menu._needsScrollbar = (): boolean => {
+            return false;
+        };
+        // Disable scrolling in inner scrollView.
+        // This causes the outer scrollView to be the only scrollable area.
+        this.menu.actor.enableMouseScrolling = false;
     }
 
     private static debounceID: number = -1;

--- a/src/randomWallpaperMenu.ts
+++ b/src/randomWallpaperMenu.ts
@@ -175,13 +175,6 @@ class RandomWallpaperMenu {
             }
         });
 
-        // FIXME?: This triggers by leaving the underlying popupMenu and blocks previewing the items
-        // when entering from any side other than another item. (eg. spacer or the sides)
-        // this._panelMenu.menu.actor.connect('leave-event', () => {
-        //     if (!this._wallpaperController.prohibitNewWallpaper)
-        //         this._wallpaperController.resetWallpaper(this._savedBackgroundUri);
-        // });
-
         this._observedValues.push(this._settings.observe('history', this.setHistoryList.bind(this)));
     }
 

--- a/src/randomWallpaperMenu.ts
+++ b/src/randomWallpaperMenu.ts
@@ -76,7 +76,7 @@ class RandomWallpaperMenu {
         this._panelMenu.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         // Temporarily pause timer
-        const pauseTimerItem = new PopupMenu.PopupSwitchMenuItem('Pause timer', false);
+        const pauseTimerItem = new PopupMenu.PopupSwitchMenuItem('Pause Timer', false);
 
         pauseTimerItem.connect('toggled', (_, state: boolean) => {
             this._backendConnection.setBoolean('pause-timer', state);

--- a/src/randomWallpaperMenu.ts
+++ b/src/randomWallpaperMenu.ts
@@ -264,7 +264,7 @@ class RandomWallpaperMenu {
             // Make sure no other preview or reset event overwrites our setWallpaper!
             this._wallpaperController.prohibitNewWallpaper = true;
 
-            this._wallpaperController.setWallpaper(entry.id).then(() => {
+            this._wallpaperController.setWallpaper(entry).then(() => {
                 this._wallpaperController.prohibitNewWallpaper = false;
 
                 if (this._settings.getInt('change-type') as Mode === Mode.LOCKSCREEN && this._savedBackgroundUri) {

--- a/src/randomWallpaperMenu.ts
+++ b/src/randomWallpaperMenu.ts
@@ -31,7 +31,6 @@ class RandomWallpaperMenu {
     private _observedValues: number[] = [];
     private _observedBackgroundValues: number[] = [];
 
-    private _currentBackgroundSection;
     private _previewBackgroundSection;
 
     private _historySection;
@@ -68,11 +67,6 @@ class RandomWallpaperMenu {
         this._panelMenu.menu.addMenuItem(this._previewBackgroundSection);
         this.previewWidget = new CustomElements.PreviewWidget(this._panelMenu.menu.actor.width);
         this._previewBackgroundSection.actor.add_child(this.previewWidget);
-        this._panelMenu.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-
-        // current background section
-        this._currentBackgroundSection = new PopupMenu.PopupMenuSection();
-        this._panelMenu.menu.addMenuItem(this._currentBackgroundSection);
         this._panelMenu.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         // history section
@@ -230,33 +224,15 @@ class RandomWallpaperMenu {
     }
 
     /**
-     * Recreates the current background section based on the history.
-     */
-    setCurrentBackgroundElement(): void {
-        this._currentBackgroundSection.removeAll();
-
-        const historyController = this._wallpaperController.getHistoryController();
-        const history = historyController.history;
-
-        if (history.length > 0) {
-            const currentImage = new CustomElements.CurrentImageElement(history[0]);
-            this._currentBackgroundSection.addMenuItem(currentImage);
-
-            this.previewWidget.preview(history[0].path);
-        }
-    }
-
-    /**
      * Recreates the history list based on the history.
      */
     setHistoryList(): void {
         this._wallpaperController.update();
-        this.setCurrentBackgroundElement();
 
         const historyController = this._wallpaperController.getHistoryController();
         const history = historyController.history;
 
-        if (history.length <= 1) {
+        if (history.length === 0) {
             this.clearHistoryList();
             return;
         }

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -20,3 +20,10 @@
 .rwg-history-time {
     font-size: 80%;
 }
+
+.rwg-preview-image {
+    border-radius: 0.3em;
+    padding-top: 0.3em;
+    padding-bottom: 0.3em;
+    background-color: rgba(0,0,0,0.2);
+}

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -27,3 +27,7 @@
     padding-bottom: 0.3em;
     background-color: rgba(0,0,0,0.2);
 }
+
+.rwg-submenu-separator {
+    background-color: rgba(255,255,255,0.1);
+}

--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -2,10 +2,6 @@
     font-size: 130%;
 }
 
-.rwg-recent-label {
-    font-size: 90%;
-}
-
 .rwg-history-index {
     text-align: left;
     padding-top: .4em;


### PR DESCRIPTION
Change how images are previewed in the popup menu.

![Screenshot](https://github.com/ifl0w/RandomWallpaperGnome3/assets/5549805/2286c142-73c2-4d78-a33c-2b549b68151e)
