### PR TITLE
Bugfixes

### DIFF
--- a/src/manager/externalWallpaperManager.ts
+++ b/src/manager/externalWallpaperManager.ts
@@ -45,7 +45,7 @@ abstract class ExternalWallpaperManager extends WallpaperManager {
      * @param {string[]} wallpaperPaths Array of paths to the desired wallpapers, should match the display count
      * @param {Mode} mode Enum indicating what images to change
      */
-    async setWallpaper(wallpaperPaths: string[], mode: Mode): Promise<void> {
+    async setWallpaper(wallpaperPaths: string[], mode: Mode = Mode.BACKGROUND): Promise<void> {
         if (wallpaperPaths.length < 1)
             throw new Error('Empty wallpaper array');
 

--- a/src/manager/hydraPaper.ts
+++ b/src/manager/hydraPaper.ts
@@ -1,6 +1,12 @@
+import Gio from 'gi://Gio';
+
 import * as Utils from '../utils.js';
+import {Settings} from './../settings.js';
 
 import {ExternalWallpaperManager} from './externalWallpaperManager.js';
+
+// https://gjs.guide/guides/gjs/asynchronous-programming.html#promisify-helper
+Gio._promisify(Gio.Subprocess.prototype, 'communicate_utf8_async', 'communicate_utf8_finish');
 
 /**
  * Wrapper for HydraPaper using it as a manager.
@@ -9,15 +15,19 @@ class HydraPaper extends ExternalWallpaperManager {
     protected readonly _possibleCommands = ['hydrapaper', 'org.gabmus.hydrapaper'];
 
     /**
+     * We have to know if HydraPaper is in a version >= 3.3.2
+     * With that version the behavior changed to automatic light/dark mode detection.
+     */
+    private static _versionIsOld?: boolean;
+
+    /**
      * Sets the background image in light and dark mode.
      *
      * @param {string[]} wallpaperPaths Array of strings to image files
      */
     protected async _setBackground(wallpaperPaths: string[]): Promise<void> {
         await this._createCommandAndRun(wallpaperPaths);
-
-        // Manually set key for darkmode because HydraPaper might be in a version below 3.3.2 which only sets light mode
-        Utils.setPictureUriOfSettingsObject(this._backgroundSettings, this._backgroundSettings.getString('picture-uri'));
+        await this._syncColorModes(this._backgroundSettings, this._backgroundSettings);
     }
 
     /**
@@ -34,7 +44,7 @@ class HydraPaper extends ExternalWallpaperManager {
         await this._createCommandAndRun(wallpaperPaths);
 
         this._screensaverSettings.setString('picture-options', 'spanned');
-        Utils.setPictureUriOfSettingsObject(this._screensaverSettings, this._backgroundSettings.getString('picture-uri-dark'));
+        await this._syncColorModes(this._screensaverSettings, this._backgroundSettings);
 
         // HydraPaper possibly changed these, change them back
         this._backgroundSettings.setString('picture-uri', tmpBackground);
@@ -61,6 +71,74 @@ class HydraPaper extends ExternalWallpaperManager {
         command = command.concat(wallpaperArray);
 
         await this._runExternal(command);
+    }
+
+    /**
+     * Since version 3.3.2 HydraPaper sets the mode automatically depending on the currently used dark/light mode.
+     * HydraPaper might be in a version below 3.3.2 which only sets light mode.
+     *
+     * @param {Settings} sourceSettings Settings object containing the picture-uri to sync from
+     * @param {Settings} targetSettings Settings object containing the picture-uri to sync to
+     */
+    private async _syncColorModes(sourceSettings: Settings, targetSettings: Settings): Promise<void> {
+        if (HydraPaper._versionIsOld === undefined || HydraPaper._versionIsOld === null)
+            await this._getVersion();
+
+        // The old version only sets light mode and we can sync simply sync to dark mode
+        if (HydraPaper._versionIsOld) {
+            Utils.setPictureUriOfSettingsObject(targetSettings, sourceSettings.getString('picture-uri'));
+            return;
+        }
+
+        /**
+         * The new version sets the correct mode automatically.
+         * We have to guess which one it is and sync to the other.
+         */
+        const interfaceSettings = new Settings('org.gnome.desktop.interface');
+
+        // 'default', 'prefer-dark', 'prefer-light'
+        const theme = interfaceSettings.getString('color-scheme');
+
+        if (theme === 'default' || theme === 'prefer-light')
+            Utils.setPictureUriOfSettingsObject(targetSettings, sourceSettings.getString('picture-uri'));
+
+        if (theme === 'prefer-dark')
+            Utils.setPictureUriOfSettingsObject(targetSettings, sourceSettings.getString('picture-uri-dark'));
+    }
+
+    /**
+     * Really really really annoying and awkward version detection because HydraPaper doesn't state it anywhere… at all.
+     *
+     * This tests if the argument '--dark' is known:
+     * Versions < 3.3.2 know that argument
+     * Versions >= 3.3.2 don't know that argument
+     */
+    // https://gjs.guide/guides/gio/subprocesses.html#communicating-with-processes
+    private async _getVersion(): Promise<void> {
+        if (!ExternalWallpaperManager._command || ExternalWallpaperManager._command.length < 1)
+            throw new Error('Command empty!');
+
+        /**
+         * We care for the success/failure of '--dark'.
+         * '--cli' is evaluated before, so we have to give a fake wallpaper path to pass that check.
+         */
+        const command = ExternalWallpaperManager._command.concat(['--dark', '--cli', 'dummyWallpaperPath']);
+        const proc = Gio.Subprocess.new(command, Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE);
+
+        const [_, stderr] = await proc.communicate_utf8_async(null, null);
+
+        // We expect this to fail
+        if (proc.get_successful())
+            throw new Error('HydraPaper did not fail.');
+
+        // Assuming new version with this specific error.
+        if (stderr && stderr.includes('error: unrecognized arguments: --dark')) {
+            HydraPaper._versionIsOld = false;
+            return;
+        }
+
+        // Otherwise assume it's the old version
+        HydraPaper._versionIsOld = true;
     }
 
     /**

--- a/src/manager/hydraPaper.ts
+++ b/src/manager/hydraPaper.ts
@@ -84,7 +84,7 @@ class HydraPaper extends ExternalWallpaperManager {
         if (HydraPaper._versionIsOld === undefined || HydraPaper._versionIsOld === null)
             await this._getVersion();
 
-        // The old version only sets light mode and we can sync simply sync to dark mode
+        // The old version only sets light mode and we can simply sync to dark mode
         if (HydraPaper._versionIsOld) {
             Utils.setPictureUriOfSettingsObject(targetSettings, sourceSettings.getString('picture-uri'));
             return;
@@ -107,7 +107,8 @@ class HydraPaper extends ExternalWallpaperManager {
     }
 
     /**
-     * Really really really annoying and awkward version detection because HydraPaper doesn't state it anywhere… at all.
+     * Workaround for detecting old HydraPaper versions by testing supported command-line options.
+     * This has to be done because there is no dedicated way to list the version (i.e., there is no --version option).
      *
      * This tests if the argument '--dark' is known:
      * Versions < 3.3.2 know that argument


### PR DESCRIPTION
This fixes my hover preview problems I had.

After many, many restarts I found actually 3 bugs interconnected:
* My gsettings contained an old `change-type` which was still a string instead of a number.
* I did not correctly overwrite a parent function in `externalWallpaperManager.ts`.
* The HydraPaper darkmode removal was more severe than I expected initially, and the logic needs to be aware of the version to work correctly. Annoyingly I haven't found the version number anywhere.

---

Fun fact: Despite the docs, example and TS saying there should be `proc.communicate_utf8_async(null, null)` available, it isn't and I get the error that there aren't enough parameter. I still have to manually generate that function with `Gio._promisify()` - strange.