### PR TITLE
Remove description of legacy limitation

### DIFF
--- a/src/ui/pageGeneral.blp
+++ b/src/ui/pageGeneral.blp
@@ -33,7 +33,7 @@ Adw.PreferencesPage page_general {
 
         Adw.ActionRow multiple_displays_row {
             title: _("Different Wallpapers on Multiple Displays");
-            subtitle: _("Requires HydraPaper or Superpaper.\nFills from History.");
+            subtitle: _("Requires HydraPaper or Superpaper.");
             sensitive: false;
 
             Switch enable_multiple_displays {


### PR DESCRIPTION
It's possible to fetch new ones for quite some while now. Fill from history is only used as fallback and when setting a specific wallpaper from history.