### PR TITLE
Allow to set "scaled" mode instead of zoom.

### DIFF
--- a/src/manager/defaultWallpaperManager.ts
+++ b/src/manager/defaultWallpaperManager.ts
@@ -53,8 +53,9 @@ class DefaultWallpaperManager extends WallpaperManager {
         if (Utils.isImageMerged(wallpaperURI))
             // merged wallpapers need mode "spanned"
             backgroundSettings.setString('picture-options', 'spanned');
+        else if("fit-display")
+            backgroundSettings.setString('picture-options', 'scaled');
         else
-            // single wallpapers need mode "zoom"
             backgroundSettings.setString('picture-options', 'zoom');
 
         Utils.setPictureUriOfSettingsObject(backgroundSettings, wallpaperURI);
@@ -73,8 +74,9 @@ class DefaultWallpaperManager extends WallpaperManager {
         if (Utils.isImageMerged(wallpaperURI))
             // merged wallpapers need mode "spanned"
             screensaverSettings.setString('picture-options', 'spanned');
+        else if("fit-display")
+            backgroundSettings.setString('picture-options', 'scaled');
         else
-            // single wallpapers need mode "zoom"
             screensaverSettings.setString('picture-options', 'zoom');
 
         Utils.setPictureUriOfSettingsObject(screensaverSettings, wallpaperURI);

--- a/src/manager/hydraPaper.ts
+++ b/src/manager/hydraPaper.ts
@@ -69,6 +69,10 @@ class HydraPaper extends ExternalWallpaperManager {
         // hydrapaper --cli PATH PATH PATH
         command.push('--cli');
         command = command.concat(wallpaperArray);
+        if ("fit-display")
+            command.push('--modes');
+            command = command.concat(Array(wallpaperArray.length).fill("fit_blur"))
+        }
 
         await this._runExternal(command);
     }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -114,6 +114,10 @@ class RandomWallpaperSettings extends ExtensionPreferences {
             this._getAs(builder, 'enable_multiple_displays'),
             'active',
             Gio.SettingsBindFlags.DEFAULT);
+        settings.bind('fit-display',
+            this._getAs(builder, 'fit-display'),
+            'active',
+            Gio.SettingsBindFlags.DEFAULT);
 
         this._bindButtons(settings, backendConnection, builder, sources, window);
         this._bindHistorySection(settings, backendConnection, builder, window);

--- a/src/ui/pageGeneral.blp
+++ b/src/ui/pageGeneral.blp
@@ -31,6 +31,15 @@ Adw.PreferencesPage page_general {
             use-subtitle: true;
         }
 
+        Adw.ActionRow fit_display_row {
+            title: _("Fit Entire Into Screen");
+            subtitle: _("Fit the entire image into the screen, leaving black stripes around the Image if it does not have the same ratio. If unset, the images are instead cropped to fit your screen. If you're using hydrapaper, the black strip are replaced with the blurred zoom image.")
+
+            Switch fit_display {
+                valign: center;
+            }
+        }
+
         Adw.ActionRow multiple_displays_row {
             title: _("Different Wallpapers on Multiple Displays");
             subtitle: _("Requires HydraPaper or Superpaper.\nFills from History.");


### PR DESCRIPTION
Some image provider like Artstation do not care about providing images in landscape ratios. In portrait images, using the default fit mode 'zoom' is devastating, often showing only the lower bust and the hips of a character. I would suggest to add an option to allow to use the 'scaled' mode instead and fit the entire background image _inside_ the display.

This is a draft; I couldn't figure out how to read the settings from the various wallpaper managers.