### PR TITLE
Gnome 46

### DIFF
--- a/src/historyMenuElements.ts
+++ b/src/historyMenuElements.ts
@@ -595,7 +595,7 @@ class HistorySection extends PopupMenu.PopupMenuSection {
             overlay_scrollbars: true,
         });
 
-        this.actor.add_actor(this.box);
+        this.actor.add_child(this.box);
     }
 
     /**

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": [ "45" ],
+  "shell-version": [ "45", "46" ],
   "uuid": "randomwallpaper@iflow.space",
   "settings-schema": "org.gnome.shell.extensions.space.iflow.randomwallpaper",
   "name": "Random Wallpaper",


### PR DESCRIPTION
https://gjs.guide/extensions/upgrading/gnome-shell-46.html

Pretty straightforward update.

* https://gjs.guide/extensions/upgrading/gnome-shell-46.html#clutter-container
    [`Clutter.Container.add_actor()`](https://gjs-docs.gnome.org/clutter13~13/clutter.container#method-add_actor) is deprecated and should be replaced with [`Clutter.Actor.add_child()`](https://gjs-docs.gnome.org/clutter13~13/clutter.actor#method-add_child)